### PR TITLE
Remove AWSMarketplaceCustomer model

### DIFF
--- a/src/backend/model/model.go
+++ b/src/backend/model/model.go
@@ -123,7 +123,6 @@ var ContextKeys = struct {
 }
 
 var Models = []interface{}{
-	&AWSMarketplaceCustomer{},
 	&ErrorObject{},
 	&ErrorGroup{},
 	&ErrorGroupEmbeddings{},
@@ -257,9 +256,8 @@ type Workspace struct {
 	Projects                    []Project
 	MigratedFromProjectID       *int // Column can be removed after migration is done
 	StripeCustomerID            *string
-	AWSMarketplaceCustomer      *AWSMarketplaceCustomer `gorm:"foreignKey:WorkspaceID"`
-	PlanTier                    string                  `gorm:"default:Free"`
-	UnlimitedMembers            bool                    `gorm:"default:false"`
+	PlanTier                    string `gorm:"default:Free"`
+	UnlimitedMembers            bool   `gorm:"default:false"`
 	BillingPeriodStart          *time.Time
 	BillingPeriodEnd            *time.Time
 	NextInvoiceDate             *time.Time
@@ -361,14 +359,6 @@ type WorkspaceAccessRequest struct {
 	Model
 	AdminID                int `gorm:"uniqueIndex"`
 	LastRequestedWorkspace int
-}
-
-type AWSMarketplaceCustomer struct {
-	Model
-	WorkspaceID          int `gorm:"uniqueIndex"`
-	CustomerIdentifier   *string
-	CustomerAWSAccountID *string
-	ProductCode          *string
 }
 
 type Project struct {

--- a/src/backend/private-graph/graph/resolver.go
+++ b/src/backend/private-graph/graph/resolver.go
@@ -372,19 +372,6 @@ func (r *Resolver) SetDefaultRetention(workspace *model.Workspace) {
 	}
 }
 
-func (r *Resolver) GetAWSMarketPlaceWorkspace(ctx context.Context, workspaceID int) (*model.Workspace, error) {
-	var workspace model.Workspace
-	if err := r.DB.WithContext(ctx).
-		Model(&workspace).
-		Joins("AWSMarketplaceCustomer").
-		Where(&model.Workspace{Model: model.Model{ID: workspaceID}}).
-		Take(&workspace).
-		Error; err != nil {
-		return nil, err
-	}
-	return &workspace, nil
-}
-
 func (r *Resolver) getAdminRole(ctx context.Context, adminID int, workspaceID int) (string, []int, error) {
 	var workspaceAdmin model.WorkspaceAdmin
 	if err := r.DB.WithContext(ctx).Where(&model.WorkspaceAdmin{AdminID: adminID, WorkspaceID: workspaceID}).Take(&workspaceAdmin).Error; err != nil {

--- a/src/backend/private-graph/graph/schema.resolvers.go
+++ b/src/backend/private-graph/graph/schema.resolvers.go
@@ -6325,11 +6325,6 @@ func (r *queryResolver) BillingDetails(ctx context.Context, workspaceID int) (*m
 		return nil, err
 	}
 
-	awsMPWorkspace, err := r.GetAWSMarketPlaceWorkspace(ctx, workspaceID)
-	if err != nil {
-		return nil, err
-	}
-
 	settings, err := r.Store.GetAllWorkspaceSettings(ctx, workspaceID)
 	if err != nil {
 		return nil, err
@@ -6506,12 +6501,6 @@ func (r *queryResolver) BillingDetails(ctx context.Context, workspaceID int) (*m
 		LogsBillingLimit:     logsLimit,
 		TracesBillingLimit:   tracesLimit,
 	}
-	if awsMPWorkspace != nil && awsMPWorkspace.AWSMarketplaceCustomer != nil {
-		details.Plan.AWSMpSubscription.CustomerIdentifier = pointy.StringValue(awsMPWorkspace.AWSMarketplaceCustomer.CustomerIdentifier, "")
-		details.Plan.AWSMpSubscription.CustomerAWSAccountID = pointy.StringValue(awsMPWorkspace.AWSMarketplaceCustomer.CustomerAWSAccountID, "")
-		details.Plan.AWSMpSubscription.ProductCode = pointy.StringValue(awsMPWorkspace.AWSMarketplaceCustomer.ProductCode, "")
-	}
-
 	return details, nil
 }
 

--- a/src/backend/worker/worker_test.go
+++ b/src/backend/worker/worker_test.go
@@ -919,11 +919,6 @@ func TestCalculateOverages(t *testing.T) {
 		BillingPeriodStart: &now,
 		BillingPeriodEnd:   &end,
 		PlanTier:           string(model2.PlanTypeGraduated),
-		AWSMarketplaceCustomer: &model.AWSMarketplaceCustomer{
-			CustomerIdentifier:   pointy.String("customer"),
-			CustomerAWSAccountID: pointy.String("aws-account"),
-			ProductCode:          pointy.String("product"),
-		},
 	}
 	if err := DB.Create(&wMP).Error; err != nil {
 		t.Fatal(e.Wrap(err, "error inserting workspace"))


### PR DESCRIPTION
## Summary
- Removes `AWSMarketplaceCustomer` struct, `Workspace.AWSMarketplaceCustomer` field, and Models slice entry from `model/model.go`
- Removes `GetAWSMarketPlaceWorkspace()` resolver function and its caller in `schema.resolvers.go`
- Removes AWS marketplace fixture from `worker_test.go`

**-41 lines of dead AWS Marketplace SaaS code.**

Closes #27

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./model/` — all 206 tests pass
- [x] `gofmt` clean
- [ ] CI: backend build + lint + test
- [ ] CI: SonarQube + CodeQL

🤖 Agentic: submitted autonomously by Claude Code agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)