### PR TITLE
ci: fix TruffleHog on K8s runners — use native binary instead of Docker action

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -136,7 +136,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install TruffleHog
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+
       - name: TruffleHog scan
-        uses: trufflesecurity/trufflehog@main
-        with:
-          extra_args: --only-verified
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            trufflehog git file://. --since-commit ${{ github.event.pull_request.base.sha }} --branch HEAD --only-verified --fail --no-update
+          elif [ "${{ github.event_name }}" = "push" ] && [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            trufflehog git file://. --since-commit ${{ github.event.before }} --only-verified --fail --no-update
+          else
+            trufflehog git file://. --only-verified --fail --no-update
+          fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -138,7 +138,9 @@ jobs:
 
       - name: Install TruffleHog
         run: |
-          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+          mkdir -p "$HOME/.local/bin"
+          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: TruffleHog scan
         run: |


### PR DESCRIPTION
## Summary
- `trufflesecurity/trufflehog@main` action uses `docker run` internally — fails on K8s ephemeral runner pods (no Docker socket)
- Switch to installing the TruffleHog binary natively via the official install script
- Scan scope logic preserved: PR scans since base SHA, push scans since `before` SHA, schedule scans full repo

## Test plan
- [ ] Security workflow passes on this PR (Secret Scanning job completes without Docker error)
- [ ] Re-run on main after merge to confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)