### PR TITLE
ci: add setup-node to CodeQL JS/TS job for K8s runners

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -87,6 +87,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:


### PR DESCRIPTION
## Summary
- K8s ephemeral runner pods don't have Node.js pre-installed (bare-metal runners did)
- CodeQL autobuild fails with `Could not start Node.js — required for TypeScript extraction`
- Add `actions/setup-node@v6` before CodeQL init in the `codeql-js` job

## Test plan
- [ ] CodeQL Analysis (javascript-typescript) passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)