### PR TITLE
chore(repo): enforce LF line endings on shell scripts (HOL-10)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,8 @@ frontend/src/components/Search/Parser/antlr/* linguist-generated=true
 /.yarn/releases/** binary
 /.yarn/plugins/** binary
 __generated/* linguist-generated=true
+
+# Shell scripts must use LF — they run inside Linux containers and CRLF
+# breaks the shebang line ("/bin/sh: illegal option -" in Docker builds).
+*.sh text eol=lf
+*.bash text eol=lf


### PR DESCRIPTION
## Summary

- `.gitattributes`: add `*.sh text eol=lf` and `*.bash text eol=lf` so Windows checkouts don't autocrlf-convert shell scripts and break Docker builds with `/bin/sh: illegal option -`.

## Why

Surfaced today: a Windows checkout had all 16 `.sh` files in `infra/` and `tools/` stored with CRLF on disk. Inside a Linux container, the shebang line `#!/bin/sh -ex\r` was parsed as `-ex\r` and aborted: `/bin/sh: illegal option -`. This blocked `docker compose up` for the collector.

## Test plan

- [ ] `git clone` on a Windows machine
- [ ] Verify all `.sh` files have LF (e.g., `file infra/docker/configure-collector.sh` shows no "CRLF")
- [ ] `docker compose -f compose.yml -f compose.hobby-dotnet.yml up -d` succeeds without the shebang error

Closes [HOL-10](https://yt.brewingcoder.com/issue/HOL-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)