### PR TITLE
infra/docker: enable DevSeed by default in hobby compose (HOL-3)

### DIFF
--- a/infra/docker/compose.hobby-dotnet.yml
+++ b/infra/docker/compose.hobby-dotnet.yml
@@ -26,7 +26,7 @@ services:
             - Frontend__Uri=${REACT_APP_FRONTEND_URI:-http://localhost:3000}
             - Auth__Mode=${REACT_APP_AUTH_MODE:-Password}
             - Auth__AdminPassword=${ADMIN_PASSWORD:-}
-            - DevSeed__Enabled=${DEV_SEED_ENABLED:-false}
+            - DevSeed__Enabled=${DEV_SEED_ENABLED:-true}
             - DevSeed__AdminEmail=${DEV_SEED_ADMIN_EMAIL:-dev@holdfast.local}
             - DevSeed__AdminName=${DEV_SEED_ADMIN_NAME:-Dev Admin}
             - OTEL_EXPORTER_OTLP_ENDPOINT=http://backend:8082

--- a/infra/docker/get-project-keys.sh
+++ b/infra/docker/get-project-keys.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+# get-project-keys.sh — print all workspace/project/API-key tuples from the dev seed.
+# Run after `docker compose up` has seeded the dev instance.
+#
+# Usage:
+#   ./infra/docker/get-project-keys.sh
+#
+# Login (after seeding, hobby/dev defaults):
+#   email:    dev@holdfast.local
+#   password: $ADMIN_PASSWORD (default "password" from infra/docker/.env)
+#   URL:      http://localhost:3000
+
+docker exec postgres psql -U postgres -d postgres -At -F$'\t' -c "
+    SELECT w.name, p.name, p.secret
+    FROM projects p
+    JOIN workspaces w ON p.workspace_id = w.id
+    ORDER BY w.id, p.id;
+" | awk -F'\t' 'BEGIN{print "WORKSPACE\tPROJECT\tAPI_KEY"} {print $1"\t"$2"\t"$3}'


### PR DESCRIPTION
## Summary

- `compose.hobby-dotnet.yml`: `DevSeed__Enabled` default flipped from `false` to `true` so a fresh hobby/dev stack auto-creates an admin, workspaces, and projects with API keys.
- `infra/docker/get-project-keys.sh`: tiny helper that prints workspace / project / API-key tuples by querying the postgres container directly.

## Why

The user's stated goal for the local stack is to test forensic ingest end-to-end. That requires a project + API key. Without DevSeed, an operator has to register, log in, click through workspace/project setup, and copy an API key out of the UI before sending the first event. The DevSeedService already did all of this — just needed the default flipped on for hobby/dev. Production still defaults off (production should never auto-seed).

After `docker compose up`:
- admin: `dev@holdfast.local` (password = `$ADMIN_PASSWORD`, default `password`)
- 4 workspaces: HoldFast Dev, Koinon Dev, SignalClaude Dev, The Brewery Dev
- 1 default project per workspace (each with its own API key)

## Test plan

- [ ] Fresh `docker compose -f compose.yml -f compose.hobby-dotnet.yml up -d`
- [ ] Backend logs show `DevSeed: complete — admin=dev@holdfast.local, workspaces=4`
- [ ] `./infra/docker/get-project-keys.sh` prints all 4 workspace/project/key tuples
- [ ] Login at http://localhost:3000 with `dev@holdfast.local` / `password` works
- [ ] Restart backend → seed is idempotent (no duplicate workspaces created)

Closes [HOL-3](https://yt.brewingcoder.com/issue/HOL-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)