### PR TITLE
tests/HoldFast.E2E: add Playwright browser SDK ingest tests (HOL-4)

### DIFF
--- a/tests/HoldFast.E2E/BrowserSdkIngestTests.cs
+++ b/tests/HoldFast.E2E/BrowserSdkIngestTests.cs
@@ -1,0 +1,237 @@
+using System.Net;
+using ClickHouse.Client.ADO;
+using Microsoft.Playwright;
+using Microsoft.Playwright.NUnit;
+
+namespace HoldFast.E2E;
+
+/// <summary>
+/// Forensic ingest happy-path: a page using @holdfast-io/browser submits an
+/// error and that error lands in ClickHouse error_objects.
+///
+/// Requires the local hobby stack to be up:
+///   docker compose -f infra/docker/compose.yml -f infra/docker/compose.hobby-dotnet.yml up -d
+/// and the ClickHouse schema to be applied (see HOL-11 for migration runner).
+/// </summary>
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+public class BrowserSdkIngestTests : PageTest
+{
+    /// <summary>
+    /// Project ID seeded by DevSeed for the "HoldFast Dev / default" project.
+    /// DevSeed uses sequential IDs starting at 1; project 2 is the first dev project.
+    /// </summary>
+    private const int ProjectId = 2;
+
+    private static string BackendUrl =>
+        Environment.GetEnvironmentVariable("HOLDFAST_BACKEND_URL")
+        ?? "http://localhost:8082/public";
+
+    private static string OtlpEndpoint =>
+        Environment.GetEnvironmentVariable("HOLDFAST_OTLP_ENDPOINT")
+        ?? "http://localhost:4318";
+
+    private static string ClickHouseUrl =>
+        Environment.GetEnvironmentVariable("HOLDFAST_CLICKHOUSE_URL")
+        ?? "Host=localhost;Port=8123;Database=default;Username=default;Password=";
+
+    private static string RepoRoot => Path.GetFullPath(Path.Combine(
+        TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", ".."));
+
+    private HttpListener? _listener;
+    private string _serverBaseUrl = "";
+
+    [SetUp]
+    public void StartLocalFileServer()
+    {
+        // Serve the sample page + SDK over HTTP so the browser sees an http:// origin
+        // (file:// origins are treated as null in CORS and break the SDK's exporters).
+        var port = GetFreePort();
+        _serverBaseUrl = $"http://localhost:{port}";
+        _listener = new HttpListener();
+        _listener.Prefixes.Add($"{_serverBaseUrl}/");
+        _listener.Start();
+        _ = Task.Run(ServeAsync);
+    }
+
+    [TearDown]
+    public void StopLocalFileServer()
+    {
+        try { _listener?.Stop(); _listener?.Close(); } catch { /* best-effort */ }
+    }
+
+    private async Task ServeAsync()
+    {
+        while (_listener?.IsListening == true)
+        {
+            HttpListenerContext ctx;
+            try { ctx = await _listener.GetContextAsync(); }
+            catch { return; }
+            // Don't block the accept loop on slow file IO — fan out per request.
+            _ = Task.Run(() => HandleRequestAsync(ctx));
+        }
+    }
+
+    private async Task HandleRequestAsync(HttpListenerContext ctx)
+    {
+        try
+        {
+            var path = ctx.Request.Url!.AbsolutePath.TrimStart('/');
+            if (string.IsNullOrEmpty(path)) path = "tests/sample-browser/index.html";
+            var filePath = Path.Combine(RepoRoot, path);
+            if (File.Exists(filePath))
+            {
+                var bytes = await File.ReadAllBytesAsync(filePath);
+                ctx.Response.ContentType = filePath.EndsWith(".html") ? "text/html"
+                    : filePath.EndsWith(".js") || filePath.EndsWith(".cjs") ? "application/javascript"
+                    : filePath.EndsWith(".map") ? "application/json"
+                    : "application/octet-stream";
+                ctx.Response.ContentLength64 = bytes.Length;
+                await ctx.Response.OutputStream.WriteAsync(bytes);
+            }
+            else
+            {
+                ctx.Response.StatusCode = 404;
+            }
+        }
+        catch { /* client likely disconnected */ }
+        finally { try { ctx.Response.Close(); } catch { } }
+    }
+
+    private static int GetFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private string SamplePageUrl() => $"{_serverBaseUrl}/tests/sample-browser/index.html";
+
+    [Test]
+    public async Task Browser_TriggeredError_LandsInClickHouse()
+    {
+        // Capture all network requests at BrowserContext level so Web Worker
+        // traffic (the SDK spins up a worker for async export) is also captured.
+        var allRequests = new List<string>();
+        var sdkRequests = new List<string>();
+        Context.Request += (_, req) =>
+        {
+            allRequests.Add($"{req.Method} {req.Url}");
+            if (req.Url.Contains(":8082/") || req.Url.Contains(":4318/") || req.Url.Contains(":4317/"))
+                sdkRequests.Add($"{req.Method} {req.Url}");
+        };
+
+        // Capture page console + page errors — SDK warns to console when ingest fails
+        var consoleMessages = new List<string>();
+        var pageErrors = new List<string>();
+        Page.Console += (_, msg) => consoleMessages.Add($"[{msg.Type}] {msg.Text}");
+        Page.PageError += (_, err) => pageErrors.Add(err);
+
+        // Capture response bodies for SDK requests so we can see GraphQL errors
+        var sdkResponses = new List<string>();
+        Context.Response += (_, resp) =>
+        {
+            if (resp.Url.Contains(":8082/public") || resp.Url.Contains(":4318/"))
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        var body = await resp.TextAsync();
+                        sdkResponses.Add($"{resp.Status} {resp.Url}\n{body.Substring(0, Math.Min(400, body.Length))}");
+                    }
+                    catch { }
+                });
+            }
+        };
+
+        var pageUri = $"{SamplePageUrl()}?project_id={ProjectId}" +
+                      $"&backend_url={Uri.EscapeDataString(BackendUrl)}" +
+                      $"&otlp_endpoint={Uri.EscapeDataString(OtlpEndpoint)}";
+
+        await Page.GotoAsync(pageUri, new() { WaitUntil = WaitUntilState.DOMContentLoaded, Timeout = 30_000 });
+
+        // Wait for SDK init to complete (page sets a window flag on success)
+        await Page.WaitForFunctionAsync("() => window.__holdfast_sdk_ready === true",
+            new PageWaitForFunctionOptions { Timeout = 10_000 });
+
+        // Tag this error so we can find it in ClickHouse — matches the page's
+        // synthetic message format `HoldFast smoke test error @ <timestamp>`
+        var beforeTs = DateTime.UtcNow.AddSeconds(-5);
+
+        await Page.ClickAsync("#btn-error");
+
+        // Allow the SDK to batch + flush. The browser SDK uses an OTLP exporter
+        // with default batch settings — events may take a few seconds to ship.
+        await Task.Delay(8_000);
+
+        TestContext.Out.WriteLine("All requests captured:\n" + string.Join("\n", allRequests));
+        TestContext.Out.WriteLine($"\nSDK (8082/4318/4317) requests: {sdkRequests.Count}");
+        TestContext.Out.WriteLine("\n=== Console messages ===\n" + string.Join("\n", consoleMessages));
+        TestContext.Out.WriteLine("\n=== Page errors ===\n" + string.Join("\n", pageErrors));
+        TestContext.Out.WriteLine("\n=== SDK response bodies ===\n" + string.Join("\n---\n", sdkResponses));
+
+        Assert.That(sdkRequests, Is.Not.Empty,
+            "Expected at least one request to localhost (SDK should ship the error to backend or collector).\n" +
+            "All requests:\n" + string.Join("\n", allRequests));
+
+        // Now confirm the error landed in ClickHouse
+        await using var conn = new ClickHouseConnection(ClickHouseUrl);
+        await conn.OpenAsync();
+
+        // error_objects holds individual occurrences (ProjectID + Timestamp);
+        // error_groups holds the deduplicated record with the Event message.
+        // Count occurrences for our project since the click — first ingest end-to-end.
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            SELECT count()
+            FROM error_objects
+            WHERE ProjectID = {projectId:Int32}
+              AND Timestamp >= {since:DateTime64(6)}";
+        cmd.Parameters.Add(new ClickHouse.Client.ADO.Parameters.ClickHouseDbParameter
+        {
+            ParameterName = "projectId",
+            Value = ProjectId
+        });
+        cmd.Parameters.Add(new ClickHouse.Client.ADO.Parameters.ClickHouseDbParameter
+        {
+            ParameterName = "since",
+            Value = beforeTs
+        });
+
+        var count = Convert.ToInt64(await cmd.ExecuteScalarAsync());
+
+        Assert.That(count, Is.GreaterThanOrEqualTo(1),
+            $"Expected at least one error_objects row matching the synthetic error " +
+            $"for project {ProjectId} since {beforeTs:O}. SDK requests captured:\n" +
+            string.Join("\n", sdkRequests));
+    }
+
+    [Test]
+    public async Task Browser_PageLoad_SdkInitializesWithoutError()
+    {
+        var consoleErrors = new List<string>();
+        Page.Console += (_, msg) =>
+        {
+            if (msg.Type == "error") consoleErrors.Add(msg.Text);
+        };
+
+        var pageUri = $"{SamplePageUrl()}?project_id={ProjectId}" +
+                      $"&backend_url={Uri.EscapeDataString(BackendUrl)}";
+
+        await Page.GotoAsync(pageUri, new() { WaitUntil = WaitUntilState.DOMContentLoaded, Timeout = 30_000 });
+        await Page.WaitForFunctionAsync("() => window.__holdfast_sdk_ready === true",
+            new PageWaitForFunctionOptions { Timeout = 10_000 });
+
+        var sdkError = await Page.EvaluateAsync<string?>("() => window.__holdfast_sdk_error ?? null");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sdkError, Is.Null, "SDK reported an init error.");
+            Assert.That(consoleErrors, Is.Empty,
+                "Console errors during SDK init:\n" + string.Join("\n", consoleErrors));
+        });
+    }
+}

--- a/tests/HoldFast.E2E/HoldFast.E2E.csproj
+++ b/tests/HoldFast.E2E/HoldFast.E2E.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ClickHouse.Client" Version="7.10.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.51.0" />

--- a/tests/sample-browser/index.html
+++ b/tests/sample-browser/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>HoldFast Browser SDK — Ingest Smoke Test</title>
+    <script>
+        // The SDK skips initialization if navigator.webdriver is true (bot detection).
+        // Playwright sets webdriver=true. The SDK bypasses the check when
+        // window.Cypress is truthy, so set it for automated test runs.
+        if (navigator.webdriver) window.Cypress = {};
+    </script>
+    <script src="../../sdk/highlight-run/dist/index.umd.cjs"></script>
+    <style>
+        body { font-family: system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; }
+        button { display: block; margin: 0.5rem 0; padding: 0.75rem 1.25rem; font-size: 1rem; cursor: pointer; }
+        #status { background: #f0f0f0; padding: 1rem; border-radius: 4px; font-family: monospace; white-space: pre-wrap; min-height: 4rem; margin-top: 1rem; }
+        .ok { color: green; }
+        .err { color: crimson; }
+    </style>
+</head>
+<body>
+    <h1>HoldFast Browser SDK — Ingest Smoke Test</h1>
+    <p>
+        Project ID: <code id="pid"></code> &nbsp;
+        Backend: <code id="be"></code>
+    </p>
+
+    <button id="btn-error">Trigger JS Error</button>
+    <button id="btn-console">Log to console (info)</button>
+    <button id="btn-identify">Identify user</button>
+    <button id="btn-track">Track custom event</button>
+
+    <h3>Status</h3>
+    <div id="status">SDK loading…</div>
+
+    <script>
+        // Read project_id and backend from URL params, default to project 2 (HoldFast Dev / default)
+        const params = new URLSearchParams(location.search);
+        const projectID = params.get('project_id') || '2';
+        const backendUrl = params.get('backend_url') || 'http://localhost:8082/public';
+        const otlpEndpoint = params.get('otlp_endpoint') || 'http://localhost:4318';
+
+        document.getElementById('pid').textContent = projectID;
+        document.getElementById('be').textContent = backendUrl;
+
+        const status = document.getElementById('status');
+        function log(msg, cls) {
+            const span = document.createElement('div');
+            span.textContent = `[${new Date().toISOString()}] ${msg}`;
+            if (cls) span.className = cls;
+            status.appendChild(span);
+        }
+
+        try {
+            H.init(projectID, {
+                backendUrl,
+                otlpEndpoint,
+                serviceName: 'holdfast-browser-smoke-test',
+                environment: 'test',
+                networkRecording: { enabled: true, recordHeadersAndBody: true },
+            });
+            log(`SDK initialized — project ${projectID}`, 'ok');
+            // Mark globally so Playwright can detect SDK readiness
+            window.__holdfast_sdk_ready = true;
+        } catch (e) {
+            log(`SDK init failed: ${e.message}`, 'err');
+            window.__holdfast_sdk_error = e.message;
+        }
+
+        document.getElementById('btn-error').addEventListener('click', () => {
+            log('Calling H.consumeError…');
+            try {
+                H.consumeError(new Error(`HoldFast smoke test error @ ${Date.now()}`));
+                log('H.consumeError returned', 'ok');
+            } catch (e) {
+                log(`H.consumeError threw: ${e.message}`, 'err');
+            }
+            // Also do a fallback: throw async so window.onerror also has a chance
+            setTimeout(() => {
+                throw new Error(`HoldFast smoke test error (async) @ ${Date.now()}`);
+            }, 0);
+        });
+
+        document.getElementById('btn-console').addEventListener('click', () => {
+            log('Logging to console…');
+            console.log(`HoldFast smoke test info log @ ${Date.now()}`);
+        });
+
+        document.getElementById('btn-identify').addEventListener('click', () => {
+            const email = `smoke-test-${Date.now()}@holdfast.local`;
+            log(`Identifying as ${email}…`);
+            H.identify(email, { id: 'smoke-test-user', source: 'sample-browser' });
+        });
+
+        document.getElementById('btn-track').addEventListener('click', () => {
+            log('Tracking custom event…');
+            H.track('smoke_test_clicked', { ts: Date.now() });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds the test infrastructure for verifying that the `@holdfast-io/browser` SDK can ingest forensic data (errors, sessions) end-to-end against the local hobby stack.

- `tests/sample-browser/index.html` — minimal page that initializes `@holdfast-io/browser` and exposes buttons to trigger errors / identify users / track events
- `tests/HoldFast.E2E/BrowserSdkIngestTests.cs` — two NUnit + Playwright tests:
  - **`Browser_PageLoad_SdkInitializesWithoutError`** — passes; confirms SDK loads cleanly
  - **`Browser_TriggeredError_LandsInClickHouse`** — currently fails on three known backend bugs (HOL-11, HOL-12, HOL-13); test passes once those land
- Tiny in-process `HttpListener` so the page serves over `http://` (the SDK's OTel exporters get angry from `file://` origins)
- ClickHouse.Client 7.10.0 added to the .csproj for the verification query

## Findings (filed separately, blocking HOL-4)

| Ticket | Issue |
|---|---|
| [HOL-11](https://yt.brewingcoder.com/issue/HOL-11) | `.NET` backend has no ClickHouse migration runner — tables never created |
| [HOL-12](https://yt.brewingcoder.com/issue/HOL-12) | Backend crashes on startup when Kafka topics aren't pre-created |
| [HOL-13](https://yt.brewingcoder.com/issue/HOL-13) | `.NET` PublicMutation wraps args in input objects, breaking the SDK (sends flat args) |

Bonus footgun: the SDK skips initialization if `navigator.webdriver === true` (bot detection). Playwright sets that flag, so the sample page sets `window.Cypress = {}` to opt back in for automated runs — the SDK already special-cases Cypress.

## Test plan

- [ ] `cd src/dotnet && dotnet build HoldFast.Backend.slnx` → clean
- [ ] `cd tests/HoldFast.E2E && dotnet test --filter BrowserSdkIngestTests.Browser_PageLoad_SdkInitializesWithoutError` → passes
- [ ] After HOL-11/12/13 land, `Browser_TriggeredError_LandsInClickHouse` passes against a fresh `docker compose up`

## Out of scope

The actual fixes for HOL-11, HOL-12, HOL-13 — each gets its own PR. This PR only adds the harness so we can quickly verify each fix end-to-end.

Closes [HOL-4](https://yt.brewingcoder.com/issue/HOL-4) when 11/12/13 also land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)