### PR TITLE
dotnet/PublicMutation: flat snake_case args matching Go schema (HOL-13)

### DIFF
--- a/src/dotnet/src/HoldFast.GraphQL.Public/PublicMutation.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/PublicMutation.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using HoldFast.Data;
 using HoldFast.Domain.Entities;
 using HoldFast.GraphQL.Public.InputTypes;
@@ -11,6 +12,13 @@ namespace HoldFast.GraphQL.Public;
 /// <summary>
 /// Public GraphQL mutations — SDK data ingestion endpoint.
 /// These are called by client SDKs to send session replay, errors, and metrics.
+///
+/// Method signatures intentionally use flat snake_case args (via the global
+/// SnakeCaseNamingConvention applied to camelCase parameter names) to match
+/// the upstream Go schema — the existing @holdfast-io/* SDKs are generated
+/// against that schema and call mutations with flat arguments. Wrapping them
+/// in input objects breaks the SDK with "argument X does not exist" errors.
+/// See HOL-13.
 /// </summary>
 public class PublicMutation
 {
@@ -19,13 +27,31 @@ public class PublicMutation
     /// Creates the session record with device/geo metadata and returns the secure ID + project ID.
     /// </summary>
     public async Task<InitializeSessionResponse> InitializeSession(
-        InitializeSessionInput input,
+        string sessionSecureId,
+        string? sessionKey,
+        string organizationVerboseId,
+        bool enableStrictPrivacy,
+        bool enableRecordingNetworkContents,
+        // The Go schema authors used camelCase for these five args even though the
+        // rest of the mutation uses snake_case. The SDK is generated against that
+        // contract, so override the global SnakeCaseNamingConvention here.
+        [GraphQLName("clientVersion")] string clientVersion,
+        [GraphQLName("firstloadVersion")] string firstloadVersion,
+        [GraphQLName("clientConfig")] string clientConfig,
+        string environment,
+        [GraphQLName("appVersion")] string? appVersion,
+        [GraphQLName("serviceName")] string? serviceName,
+        string fingerprint,
+        string clientId,
+        List<string>? networkRecordingDomains,
+        bool? disableSessionRecording,
+        string? privacySetting,
         [Service] ISessionInitializationService initService,
         [Service] IHttpContextAccessor httpContextAccessor,
         [Service] HoldFastDbContext db,
         CancellationToken ct)
     {
-        var projectId = Project.FromVerboseId(input.OrganizationVerboseId);
+        var projectId = Project.FromVerboseId(organizationVerboseId);
         var project = await db.Projects.FindAsync([projectId], ct)
             ?? throw new GraphQLException("Project not found");
 
@@ -36,20 +62,20 @@ public class PublicMutation
         var ipAddress = httpContext?.Connection.RemoteIpAddress?.ToString();
 
         var result = await initService.InitializeSessionAsync(
-            input.SessionSecureId,
-            input.SessionKey,
+            sessionSecureId,
+            sessionKey,
             project.Id,
-            input.Fingerprint,
-            input.ClientId,
-            input.ClientVersion,
-            input.FirstloadVersion,
-            input.ClientConfig,
-            input.Environment,
-            input.AppVersion,
-            input.ServiceName,
-            input.EnableStrictPrivacy,
-            input.EnableRecordingNetworkContents,
-            input.PrivacySetting,
+            fingerprint,
+            clientId,
+            clientVersion,
+            firstloadVersion,
+            clientConfig,
+            environment,
+            appVersion,
+            serviceName,
+            enableStrictPrivacy,
+            enableRecordingNetworkContents,
+            privacySetting,
             userAgent,
             acceptLanguage,
             ipAddress,
@@ -63,14 +89,16 @@ public class PublicMutation
     /// Detects first-time users and backfills unidentified sessions.
     /// </summary>
     public async Task<string> IdentifySession(
-        IdentifySessionInput input,
+        string sessionSecureId,
+        string userIdentifier,
+        JsonElement? userObject,
         [Service] ISessionInitializationService initService,
         CancellationToken ct)
     {
         var session = await initService.IdentifySessionAsync(
-            input.SessionSecureId,
-            input.UserIdentifier,
-            input.UserObject,
+            sessionSecureId,
+            userIdentifier,
+            userObject,
             ct);
 
         return session.SecureId;
@@ -80,15 +108,17 @@ public class PublicMutation
     /// Add custom properties to a session.
     /// </summary>
     public async Task<string> AddSessionProperties(
-        AddSessionPropertiesInput input,
+        string sessionSecureId,
+        JsonElement? propertiesObject,
         [Service] HoldFastDbContext db,
         CancellationToken ct)
     {
+        _ = propertiesObject; // properties handled by worker via session field updates
+
         var session = await db.Sessions
-            .FirstOrDefaultAsync(s => s.SecureId == input.SessionSecureId, ct)
+            .FirstOrDefaultAsync(s => s.SecureId == sessionSecureId, ct)
             ?? throw new GraphQLException("Session not found");
 
-        // Properties are stored as session fields — will be processed by worker
         await db.SaveChangesAsync(ct);
 
         return session.SecureId;
@@ -219,12 +249,18 @@ public class PublicMutation
     /// Add user feedback to a session.
     /// </summary>
     public async Task<string> AddSessionFeedback(
-        AddSessionFeedbackInput input,
+        string sessionSecureId,
+        string? userName,
+        string? userEmail,
+        string verbatim,
+        DateTime timestamp,
         [Service] HoldFastDbContext db,
         CancellationToken ct)
     {
+        _ = userName; _ = userEmail; _ = timestamp; // unused in current backend; kept for schema parity
+
         var session = await db.Sessions
-            .FirstOrDefaultAsync(s => s.SecureId == input.SessionSecureId, ct)
+            .FirstOrDefaultAsync(s => s.SecureId == sessionSecureId, ct)
             ?? throw new GraphQLException("Session not found");
 
         // Store feedback as a session comment with type "FEEDBACK"
@@ -232,7 +268,7 @@ public class PublicMutation
         {
             ProjectId = session.ProjectId,
             SessionId = session.Id,
-            Text = input.Verbatim,
+            Text = verbatim,
             Type = "FEEDBACK",
         };
 

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/PublicMutationTestExtensions.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/PublicMutationTestExtensions.cs
@@ -1,0 +1,55 @@
+using HoldFast.Data;
+using HoldFast.GraphQL.Public;
+using HoldFast.GraphQL.Public.InputTypes;
+using HoldFast.Shared.SessionProcessing;
+using Microsoft.AspNetCore.Http;
+
+namespace HoldFast.GraphQL.Tests;
+
+/// <summary>
+/// Test-only convenience overloads. Production PublicMutation methods take flat
+/// snake_case args (HOL-13: matches the Go schema the SDKs are generated against).
+/// These extensions accept the original input records so tests stay compact.
+/// </summary>
+internal static class PublicMutationTestExtensions
+{
+    public static Task<InitializeSessionResponse> InitializeSession(
+        this PublicMutation mutation,
+        InitializeSessionInput input,
+        ISessionInitializationService initService,
+        IHttpContextAccessor accessor,
+        HoldFastDbContext db,
+        CancellationToken ct) =>
+        mutation.InitializeSession(
+            input.SessionSecureId, input.SessionKey, input.OrganizationVerboseId,
+            input.EnableStrictPrivacy, input.EnableRecordingNetworkContents,
+            input.ClientVersion, input.FirstloadVersion, input.ClientConfig,
+            input.Environment, input.AppVersion, input.ServiceName,
+            input.Fingerprint, input.ClientId, input.NetworkRecordingDomains,
+            input.DisableSessionRecording, input.PrivacySetting,
+            initService, accessor, db, ct);
+
+    public static Task<string> IdentifySession(
+        this PublicMutation mutation,
+        IdentifySessionInput input,
+        ISessionInitializationService initService,
+        CancellationToken ct) =>
+        mutation.IdentifySession(input.SessionSecureId, input.UserIdentifier, input.UserObject,
+            initService, ct);
+
+    public static Task<string> AddSessionProperties(
+        this PublicMutation mutation,
+        AddSessionPropertiesInput input,
+        HoldFastDbContext db,
+        CancellationToken ct) =>
+        mutation.AddSessionProperties(input.SessionSecureId, input.PropertiesObject, db, ct);
+
+    public static Task<string> AddSessionFeedback(
+        this PublicMutation mutation,
+        AddSessionFeedbackInput input,
+        HoldFastDbContext db,
+        CancellationToken ct) =>
+        mutation.AddSessionFeedback(
+            input.SessionSecureId, input.UserName, input.UserEmail,
+            input.Verbatim, input.Timestamp, db, ct);
+}


### PR DESCRIPTION
## Summary

Four `PublicMutation` methods (`InitializeSession`, `IdentifySession`, `AddSessionProperties`, `AddSessionFeedback`) wrapped their arguments in `*Input` records, exposing `mutation { initializeSession(input: {...}) }` to clients. The upstream Go schema and the `@holdfast-io/*` SDKs use **flat top-level args** — `mutation { initializeSession(session_secure_id: "...", organization_verbose_id: "...", ...) }`. The mismatch made every SDK call fail with `argument 'session_secure_id' does not exist`, completely blocking ingest against the .NET backend.

This PR unwraps those four mutations to flat args and adds `[GraphQLName]` overrides for the five Go-schema arguments inside `initializeSession` that are camelCase even though everything else is snake_case (`clientVersion`, `firstloadVersion`, `clientConfig`, `appVersion`, `serviceName` — yes, the Go schema is inconsistent here).

## Why now

Surfaced while wiring up the HOL-4 ingest tests. Verified against a running stack:

```bash
curl -s -X POST http://localhost:8082/public -H "Content-Type: application/json" \
  -d '{"query":"mutation { initializeSession(session_secure_id: \"x\", organization_verbose_id: \"2\", clientVersion: \"1\", firstloadVersion: \"1\", clientConfig: \"{}\", environment: \"test\", fingerprint: \"fp\", serviceName: \"smoke\", client_id: \"c1\", enable_strict_privacy: false, enable_recording_network_contents: true) { secure_id project_id } }"}'
# Before: 400 "The argument session_secure_id does not exist"
# After:  200 {"data":{"initializeSession":{"secure_id":"x","project_id":2}}}
```

## Tests

- All 3,032 existing .NET tests still pass — the existing tests still pass `XInput` records by way of the new test-project-only `PublicMutationTestExtensions`, so nothing in the test suite needed to change at the call sites.
- New end-to-end: SDK's `initializeSession` returns 200 against the patched backend (verified manually + via PR #89's `BrowserSdkIngestTests`).

## Out of scope (filed as follow-ups)

- **HOL-14** — `pushPayload` and friends still 400 because of *type* mismatches: `payload_id` is `ID` not `Int`, `events` is `ReplayEventsInput!` not `String!`, list element nullability differs. Larger fix; needs new input-type definitions (`ReplayEventsInput`, `ReplayEventInput`).

## Test plan

- [ ] `cd src/dotnet && dotnet test HoldFast.Backend.slnx` — 3,032 / 3,032 pass
- [ ] `docker compose -f compose.yml -f compose.hobby-dotnet.yml build backend && docker compose ... up -d --force-recreate backend`
- [ ] Run the HOL-4 PR's `BrowserSdkIngestTests` — `Browser_PageLoad_SdkInitializesWithoutError` passes; `Browser_TriggeredError_LandsInClickHouse` advances from "no requests" through "InitializeSession 200" until it hits HOL-14's pushPayload 400s

Closes [HOL-13](https://yt.brewingcoder.com/issue/HOL-13). Unblocks the first hop of [HOL-4](https://yt.brewingcoder.com/issue/HOL-4); end-to-end pass also waits on [HOL-11](https://yt.brewingcoder.com/issue/HOL-11), [HOL-12](https://yt.brewingcoder.com/issue/HOL-12), [HOL-14](https://yt.brewingcoder.com/issue/HOL-14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)