### PR TITLE
dotnet/PublicMutation: align scalar/input types with Go schema (HOL-14)

### DIFF
--- a/src/dotnet/src/HoldFast.GraphQL.Public/IKafkaProducer.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/IKafkaProducer.cs
@@ -11,7 +11,7 @@ public interface IKafkaProducer
     Task ProduceSessionEventsAsync(string sessionSecureId, long payloadId, string data, CancellationToken ct);
     Task ProducePushPayloadAsync(string sessionSecureId, long payloadId, string events,
         string messages, string resources, string? webSocketEvents,
-        List<ErrorObjectInput> errors, bool? isBeacon, bool? hasSessionUnloaded,
+        List<ErrorObjectInput?> errors, bool? isBeacon, bool? hasSessionUnloaded,
         string? highlightLogs, CancellationToken ct);
     Task ProduceBackendErrorAsync(string? projectId, BackendErrorObjectInput error, CancellationToken ct);
     Task ProduceMetricAsync(MetricInput metric, CancellationToken ct);

--- a/src/dotnet/src/HoldFast.GraphQL.Public/InputTypes/ErrorInputs.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/InputTypes/ErrorInputs.cs
@@ -1,11 +1,15 @@
+using System.Text.Json;
+
 namespace HoldFast.GraphQL.Public.InputTypes;
 
 /// <summary>
 /// A single frame in an error stack trace. Maps to one line in a JS/TS stack trace.
-/// IsEval/IsNative indicate the execution context.
+/// IsEval/IsNative indicate the execution context. `args` holds opaque
+/// argument values (matches Go schema's `args: [Any]`).
 /// </summary>
 public record StackFrameInput(
     string? FunctionName,
+    List<JsonElement?>? Args,
     string? FileName,
     int? LineNumber,
     int? ColumnNumber,
@@ -24,7 +28,7 @@ public record ErrorObjectInput(
     string Source,
     int LineNumber,
     int ColumnNumber,
-    List<StackFrameInput> StackTrace,
+    List<StackFrameInput?> StackTrace,
     DateTime Timestamp,
     string? Payload);
 

--- a/src/dotnet/src/HoldFast.GraphQL.Public/InputTypes/SessionInputs.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/InputTypes/SessionInputs.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using HotChocolate;
 
 namespace HoldFast.GraphQL.Public.InputTypes;
 
@@ -54,3 +55,21 @@ public record AddSessionFeedbackInput(
 public record InitializeSessionResponse(
     string SecureId,
     int ProjectId);
+
+/// <summary>
+/// One rrweb session-replay event. Matches Go schema's ReplayEventInput.
+/// `_sid` is a numeric sequence id (the underscore-prefix is from rrweb's
+/// own type; preserved on the wire via [GraphQLName]). `data` is opaque
+/// rrweb event JSON.
+/// </summary>
+public record ReplayEventInput(
+    int Type,
+    double Timestamp,
+    [property: GraphQLName("_sid")] double Sid,
+    JsonElement Data);
+
+/// <summary>
+/// Wrapper for a batch of replay events sent in a single pushPayload call.
+/// </summary>
+public record ReplayEventsInput(
+    List<ReplayEventInput?> Events);

--- a/src/dotnet/src/HoldFast.GraphQL.Public/KafkaProducerAdapter.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/KafkaProducerAdapter.cs
@@ -23,7 +23,7 @@ public class KafkaProducerAdapter : IKafkaProducer
 
     public Task ProducePushPayloadAsync(string sessionSecureId, long payloadId, string events,
         string messages, string resources, string? webSocketEvents,
-        List<ErrorObjectInput> errors, bool? isBeacon, bool? hasSessionUnloaded,
+        List<ErrorObjectInput?> errors, bool? isBeacon, bool? hasSessionUnloaded,
         string? highlightLogs, CancellationToken ct)
     {
         var message = new

--- a/src/dotnet/src/HoldFast.GraphQL.Public/PublicMutation.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/PublicMutation.cs
@@ -132,22 +132,27 @@ public class PublicMutation
     [GraphQLDeprecated("Use pushSessionEvents instead")]
     public async Task<int> PushPayload(
         string sessionSecureId,
-        int? payloadId,
-        string events,
+        // Go schema: payload_id: ID (optional, string-on-the-wire). SDKs send a string.
+        [ID] string? payloadId,
+        ReplayEventsInput events,
         string messages,
         string resources,
         string? webSocketEvents,
-        List<ErrorObjectInput> errors,
+        // Go schema: errors: [ErrorObjectInput]! — list non-null, elements nullable.
+        List<ErrorObjectInput?> errors,
         bool? isBeacon,
         bool? hasSessionUnloaded,
         string? highlightLogs,
         [Service] IKafkaProducer kafka,
         CancellationToken ct)
     {
+        // Serialize structured events to JSON for the existing Kafka string body.
+        var eventsJson = JsonSerializer.Serialize(events);
+        var pid = ParsePayloadId(payloadId);
         await kafka.ProducePushPayloadAsync(
-            sessionSecureId, payloadId ?? 0, events, messages, resources,
+            sessionSecureId, pid, eventsJson, messages, resources,
             webSocketEvents, errors, isBeacon, hasSessionUnloaded, highlightLogs, ct);
-        return events.Length;
+        return eventsJson.Length;
     }
 
     /// <summary>
@@ -156,12 +161,13 @@ public class PublicMutation
     [GraphQLDeprecated("Use pushSessionEvents instead")]
     public async Task<bool> PushPayloadCompressed(
         string sessionSecureId,
-        int payloadId,
+        // Go schema: payload_id: ID! — non-null string-on-the-wire.
+        [ID] string payloadId,
         string data,
         [Service] IKafkaProducer kafka,
         CancellationToken ct)
     {
-        await kafka.ProduceSessionEventsAsync(sessionSecureId, payloadId, data, ct);
+        await kafka.ProduceSessionEventsAsync(sessionSecureId, ParsePayloadId(payloadId), data, ct);
         return true;
     }
 
@@ -172,26 +178,32 @@ public class PublicMutation
     /// </summary>
     public async Task<bool> PushSessionEvents(
         string sessionSecureId,
-        long payloadId,
+        // Go schema: payload_id: Int64ID! — 64-bit ID, string-on-the-wire.
+        [ID] string payloadId,
         string data,
         [Service] IKafkaProducer kafka,
         CancellationToken ct)
     {
-        await kafka.ProduceSessionEventsAsync(sessionSecureId, payloadId, data, ct);
+        await kafka.ProduceSessionEventsAsync(sessionSecureId, ParsePayloadId(payloadId), data, ct);
         return true;
     }
+
+    private static long ParsePayloadId(string? id) =>
+        long.TryParse(id, out var n) ? n : 0L;
 
     /// <summary>
     /// Push backend errors (from server-side SDKs).
     /// </summary>
     public async Task<bool> PushBackendPayload(
         string? projectId,
-        List<BackendErrorObjectInput> errors,
+        // Go schema: errors: [BackendErrorObjectInput]! — list non-null, elements nullable.
+        List<BackendErrorObjectInput?> errors,
         [Service] IKafkaProducer kafka,
         CancellationToken ct)
     {
         foreach (var error in errors)
         {
+            if (error is null) continue;
             await kafka.ProduceBackendErrorAsync(projectId, error, ct);
         }
         return true;

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/InputTypeTests.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/InputTypeTests.cs
@@ -24,8 +24,8 @@ public class InputTypeExtendedTests
             ColumnNumber: 13,
             StackTrace:
             [
-                new StackFrameInput("onClick", "app.js", 42, 13, false, false, ""),
-                new StackFrameInput("handleEvent", "react-dom.js", 100, 1, false, false, null),
+                new StackFrameInput("onClick", null, "app.js", 42, 13, false, false, ""),
+                new StackFrameInput("handleEvent", null, "react-dom.js", 100, 1, false, false, null),
             ],
             Timestamp: new DateTime(2025, 3, 15, 10, 30, 0, DateTimeKind.Utc),
             Payload: "{\"extra\":\"data\"}");
@@ -60,7 +60,7 @@ public class InputTypeExtendedTests
     [Fact]
     public void StackFrameInput_AllNulls()
     {
-        var frame = new StackFrameInput(null, null, null, null, null, null, null);
+        var frame = new StackFrameInput(null, null, null, null, null, null, null, null);
         Assert.Null(frame.FunctionName);
         Assert.Null(frame.FileName);
         Assert.Null(frame.LineNumber);
@@ -73,7 +73,7 @@ public class InputTypeExtendedTests
     [Fact]
     public void StackFrameInput_Roundtrip()
     {
-        var frame = new StackFrameInput("main", "app.go", 100, 5, true, false, "compiled");
+        var frame = new StackFrameInput("main", null, "app.go", 100, 5, true, false, "compiled");
         var json = JsonSerializer.Serialize(frame);
         var back = JsonSerializer.Deserialize<StackFrameInput>(json);
 
@@ -86,8 +86,8 @@ public class InputTypeExtendedTests
     [Fact]
     public void StackFrameInput_EvalAndNativeFlags()
     {
-        var evalFrame = new StackFrameInput("eval", "eval", 1, 1, true, false, null);
-        var nativeFrame = new StackFrameInput("[native code]", null, null, null, false, true, null);
+        var evalFrame = new StackFrameInput("eval", null, "eval", 1, 1, true, false, null);
+        var nativeFrame = new StackFrameInput("[native code]", null, null, null, null, false, true, null);
 
         Assert.True(evalFrame.IsEval);
         Assert.False(evalFrame.IsNative);

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/PublicGraphEdgeCaseTests.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/PublicGraphEdgeCaseTests.cs
@@ -220,9 +220,9 @@ public class PublicGraphEdgeCaseTests : IDisposable
     [Fact]
     public void ErrorObjectInput_Construction()
     {
-        var frames = new List<StackFrameInput>
+        var frames = new List<StackFrameInput?>
         {
-            new("main", "app.js", 42, 10, false, false, "source"),
+            new("main", null, "app.js", 42, 10, false, false, "source"),
         };
 
         var input = new ErrorObjectInput(
@@ -262,7 +262,7 @@ public class PublicGraphEdgeCaseTests : IDisposable
     [Fact]
     public void StackFrameInput_AllNullable()
     {
-        var frame = new StackFrameInput(null, null, null, null, null, null, null);
+        var frame = new StackFrameInput(null, null, null, null, null, null, null, null);
         Assert.Null(frame.FunctionName);
         Assert.Null(frame.FileName);
         Assert.Null(frame.LineNumber);

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/PublicMutationKafkaTests.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/PublicMutationKafkaTests.cs
@@ -71,7 +71,7 @@ public class PublicMutationKafkaTests
         var kafka = new FakeKafkaProducer();
 
         var result = await _mutation.PushSessionEvents(
-            "sess-abc", 42, "compressed-data",
+            "sess-abc", "42", "compressed-data",
             kafka, CancellationToken.None);
 
         Assert.True(result);
@@ -87,7 +87,7 @@ public class PublicMutationKafkaTests
         var kafka = new FakeKafkaProducer();
 
         var result = await _mutation.PushSessionEvents(
-            "sess-1", 0, "",
+            "sess-1", "0", "",
             kafka, CancellationToken.None);
 
         Assert.True(result);
@@ -101,7 +101,7 @@ public class PublicMutationKafkaTests
         var kafka = new FakeKafkaProducer();
 
         await _mutation.PushSessionEvents(
-            "sess-1", long.MaxValue, "data",
+            "sess-1", long.MaxValue.ToString(), "data",
             kafka, CancellationToken.None);
 
         Assert.Equal(long.MaxValue, kafka.SessionEvents[0].PayloadId);
@@ -307,8 +307,12 @@ public class PublicMutationKafkaTests
     }
 
     [Fact]
-    public async Task PushPayload_ReturnsEventLength()
+    public async Task PushPayload_ReturnsSerializedEventsLength()
     {
+        // HOL-14: events param is now ReplayEventsInput, not raw string. The
+        // method returns the length of the JSON-serialized payload — so we
+        // just verify it scales with the input rather than asserting an exact
+        // value (which would be brittle against JSON formatting).
         var kafka = new FakeKafkaProducer();
         var events = "[{\"type\":\"scroll\",\"data\":{\"x\":100,\"y\":200}}]";
 
@@ -316,7 +320,9 @@ public class PublicMutationKafkaTests
             "sess-1", 1, events, "", "", null, [], null, null, null,
             kafka, CancellationToken.None);
 
-        Assert.Equal(events.Length, result);
+        Assert.True(result > events.Length / 2,
+            $"Expected result ({result}) to be roughly proportional to input.");
+        Assert.Single(kafka.PushPayloads);
     }
 
     [Fact]
@@ -333,7 +339,7 @@ public class PublicMutationKafkaTests
             "sess-1", 1, "[]", "", "", null, errors, null, null, null,
             kafka, CancellationToken.None);
 
-        Assert.Equal(2, result); // "[]" has length 2
+        Assert.True(result > 0); // serialized {"events":[]} length
         Assert.Single(kafka.PushPayloads);
     }
 
@@ -358,7 +364,7 @@ public class PublicMutationKafkaTests
         var kafka = new FakeKafkaProducer();
 
         var result = await _mutation.PushPayloadCompressed(
-            "sess-compressed", 7, "compressed-data",
+            "sess-compressed", "7", "compressed-data",
             kafka, CancellationToken.None);
 
         Assert.True(result);
@@ -374,7 +380,7 @@ public class PublicMutationKafkaTests
         var kafka = new FakeKafkaProducer();
 
         var result = await _mutation.PushPayloadCompressed(
-            "sess-1", 0, "",
+            "sess-1", "0", "",
             kafka, CancellationToken.None);
 
         Assert.True(result);

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/PublicMutationTestExtensions.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/PublicMutationTestExtensions.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using HoldFast.Data;
 using HoldFast.GraphQL.Public;
 using HoldFast.GraphQL.Public.InputTypes;
@@ -52,4 +53,55 @@ internal static class PublicMutationTestExtensions
         mutation.AddSessionFeedback(
             input.SessionSecureId, input.UserName, input.UserEmail,
             input.Verbatim, input.Timestamp, db, ct);
+
+    /// <summary>
+    /// Legacy PushPayload signature: payloadId as int, events as raw JSON string.
+    /// HOL-14 changed wire types (payloadId → ID/string, events → ReplayEventsInput)
+    /// to match the Go schema. Tests historically passed raw strings; this overload
+    /// keeps them compact by parsing the legacy events string as a JSON array of
+    /// opaque rrweb events.
+    /// </summary>
+    public static Task<int> PushPayload(
+        this PublicMutation mutation,
+        string sessionSecureId,
+        int? payloadId,
+        string eventsJson,
+        string messages,
+        string resources,
+        string? webSocketEvents,
+        List<ErrorObjectInput> errors,
+        bool? isBeacon,
+        bool? hasSessionUnloaded,
+        string? highlightLogs,
+        IKafkaProducer kafka,
+        CancellationToken ct) =>
+        mutation.PushPayload(
+            sessionSecureId,
+            payloadId?.ToString(),
+            ParseLegacyEvents(eventsJson),
+            messages, resources, webSocketEvents,
+            errors.Cast<ErrorObjectInput?>().ToList(),
+            isBeacon, hasSessionUnloaded, highlightLogs,
+            kafka, ct);
+
+    private static ReplayEventsInput ParseLegacyEvents(string raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+            return new ReplayEventsInput([]);
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            if (doc.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                var events = new List<ReplayEventInput?>();
+                foreach (var elem in doc.RootElement.EnumerateArray())
+                    events.Add(new ReplayEventInput(0, 0, 0, elem.Clone()));
+                return new ReplayEventsInput(events);
+            }
+        }
+        catch (JsonException) { /* not JSON — wrap as single opaque event */ }
+
+        return new ReplayEventsInput(
+            [new ReplayEventInput(0, 0, 0, JsonSerializer.SerializeToElement(raw))]);
+    }
 }


### PR DESCRIPTION
## Summary

After [HOL-13](https://yt.brewingcoder.com/issue/HOL-13) unwrapped the input-object args, SDK calls *still* 400'd because three concrete schema types didn't match the upstream Go schema:

| Field | Go schema | .NET (before) | Result |
|---|---|---|---|
| `payload_id` | `ID` / `ID!` / `Int64ID!` (string on wire) | `int?` / `int` / `long` | SDK sends a string variable → HotChocolate type mismatch |
| `pushPayload.events` | `ReplayEventsInput!` (struct) | `string` | SDK sends nested object → type mismatch |
| `pushPayload.errors` / `pushBackendPayload.errors` | `[X]!` (nullable elements) | `[X!]!` (non-null) | nullability mismatch |
| `StackFrameInput.args` | `[Any]` | (missing field) | the SDK omits it; the Go side still expects it |

Plus the underscore-prefixed `_sid` field on `ReplayEventInput` needed an explicit `[GraphQLName]` since C# can't start an identifier with `_`.

## Approach

- New `ReplayEventInput` / `ReplayEventsInput` records.
- `payload_id` everywhere: `int`/`long` → `[ID] string`, with a small `ParsePayloadId` helper that converts back to `long` for the existing Kafka producer signatures.
- `pushPayload.events`: `string` → `ReplayEventsInput`; the structured value is JSON-serialized before forwarding to Kafka so the consumer-side contract (a string body) is unchanged. Reworking the consumer to handle structured events is [HOL-15](https://yt.brewingcoder.com/issue/HOL-15).
- `errors` lists allow nullable elements; `PushBackendPayload` skips nulls.
- `StackFrameInput.Args: List<JsonElement?>?` added (matches Go's `[Any]`).
- Test extensions in `PublicMutationTestExtensions` cushion legacy test call shapes against the new types so existing test bodies stay compact.

## Tests

- All 3,032 .NET tests pass — two existing PushPayload tests had brittle assertions comparing raw-input length to JSON-serialized output length; loosened to "result scales with input" since the exact byte count is no longer meaningful.

## Verified end-to-end

Fresh `docker compose up` (with HOL-11/12 manual workarounds) + the `BrowserSdkIngestTests` sample page → **9 SDK requests, all 200**:

```
200 http://localhost:8082/public  ← initializeSession
{"data":{"initializeSession":{"secure_id":"JcDLgzOxKT02uctiomkMAsSz6Ehh","project_id":2}}}
200 http://localhost:8082/public  ← pushPayload (was 400)
200 http://localhost:8082/public  ← pushPayload (was 400)
200 http://localhost:4318/v1/traces, /v1/metrics  ← OTLP
200 http://localhost:8082/public  ← pushPayload
200 http://localhost:8082/public  ← pushPayload
```

(was 1× 200 for initializeSession + 4× 400 for everything else before this PR)

## Out of scope

- **HOL-15** — `pushPayload.errors` is now accepted by the schema but `SessionEventsConsumer` extracts only the rrweb chunks and doesn't forward the embedded `errors` array onto `error_objects` / `error_groups`. That's the next blocker for HOL-4's end-to-end test.

## Test plan

- [ ] `cd src/dotnet && dotnet test HoldFast.Backend.slnx` → 3,032 / 3,032 pass
- [ ] Rebuild backend image, recreate, `BrowserSdkIngestTests.Browser_TriggeredError_LandsInClickHouse` advances from "all 400s" to "all 200s" (final ClickHouse assertion still fails on HOL-15)

Stacks on [#90](https://github.com/BrewingCoder/holdfast/pull/90) (HOL-13). Closes [HOL-14](https://yt.brewingcoder.com/issue/HOL-14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)