### PR TITLE
dotnet/Worker: route pushPayload errors → frontend-errors topic → error_objects (HOL-15)

### DIFF
--- a/src/dotnet/src/HoldFast.Api/Program.cs
+++ b/src/dotnet/src/HoldFast.Api/Program.cs
@@ -162,6 +162,8 @@ if (runtime.IsWorker())
     builder.Services.AddHostedService<SessionEventsWorker>();
     builder.Services.AddSingleton<ErrorGroupingConsumer>();
     builder.Services.AddHostedService<ErrorGroupingWorker>();
+    builder.Services.AddSingleton<FrontendErrorsConsumer>();
+    builder.Services.AddHostedService<FrontendErrorsWorker>();
     builder.Services.AddSingleton<MetricsConsumer>();
     builder.Services.AddHostedService<MetricsWorker>();
     builder.Services.AddSingleton<LogIngestionConsumer>();

--- a/src/dotnet/src/HoldFast.Data.ClickHouse/ClickHouseService.cs
+++ b/src/dotnet/src/HoldFast.Data.ClickHouse/ClickHouseService.cs
@@ -969,23 +969,25 @@ public class ClickHouseService : IClickHouseService, IDisposable
 
         foreach (var e in list)
         {
+            // Column names match the actual error_objects table from the Go
+            // migrations (000xxx_create_errors_table.up.sql): ID (not
+            // ErrorObjectID), VisitedURL (not URL), OSName (not OS).
+            // Event/Type live on error_groups, not error_objects.
             var sql =
-                "INSERT INTO error_objects (ProjectID, ErrorObjectID, ErrorGroupID, " +
-                "Timestamp, Event, Type, URL, Environment, OS, Browser, " +
+                "INSERT INTO error_objects (ProjectID, ID, ErrorGroupID, " +
+                "Timestamp, VisitedURL, Environment, OSName, Browser, " +
                 "ServiceName, ServiceVersion) " +
-                "VALUES ({projectId:Int32}, {errorObjectId:Int32}, {errorGroupId:Int32}, " +
-                "{ts:DateTime64(9)}, {event:String}, {type:String}, {url:String}, " +
+                "VALUES ({projectId:Int32}, {errorObjectId:Int64}, {errorGroupId:Int64}, " +
+                "{ts:DateTime64(6)}, {url:String}, " +
                 "{env:String}, {os:String}, {browser:String}, " +
                 "{serviceName:String}, {serviceVersion:String})";
 
             using var cmd = _conn.CreateCommand();
             cmd.CommandText = sql;
             cmd.AddParameter("projectId", e.ProjectId);
-            cmd.AddParameter("errorObjectId", e.ErrorObjectId);
-            cmd.AddParameter("errorGroupId", e.ErrorGroupId);
+            cmd.AddParameter("errorObjectId", (long)e.ErrorObjectId);
+            cmd.AddParameter("errorGroupId", (long)e.ErrorGroupId);
             cmd.AddParameter("ts", e.Timestamp);
-            cmd.AddParameter("event", e.Event ?? "");
-            cmd.AddParameter("type", e.Type ?? "");
             cmd.AddParameter("url", e.Url ?? "");
             cmd.AddParameter("env", e.Environment ?? "");
             cmd.AddParameter("os", e.OS ?? "");

--- a/src/dotnet/src/HoldFast.GraphQL.Public/InputTypes/ErrorInputs.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/InputTypes/ErrorInputs.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using HotChocolate;
 
 namespace HoldFast.GraphQL.Public.InputTypes;
 
@@ -6,29 +7,36 @@ namespace HoldFast.GraphQL.Public.InputTypes;
 /// A single frame in an error stack trace. Maps to one line in a JS/TS stack trace.
 /// IsEval/IsNative indicate the execution context. `args` holds opaque
 /// argument values (matches Go schema's `args: [Any]`).
+///
+/// Field names use [GraphQLName] to expose camelCase to clients — the Go schema
+/// (and the SDKs generated against it) uses camelCase here even though the
+/// global convention is snake_case. Mixed casing in the upstream contract.
 /// </summary>
 public record StackFrameInput(
-    string? FunctionName,
+    [property: GraphQLName("functionName")] string? FunctionName,
     List<JsonElement?>? Args,
-    string? FileName,
-    int? LineNumber,
-    int? ColumnNumber,
-    bool? IsEval,
-    bool? IsNative,
+    [property: GraphQLName("fileName")] string? FileName,
+    [property: GraphQLName("lineNumber")] int? LineNumber,
+    [property: GraphQLName("columnNumber")] int? ColumnNumber,
+    [property: GraphQLName("isEval")] bool? IsEval,
+    [property: GraphQLName("isNative")] bool? IsNative,
     string? Source);
 
 /// <summary>
 /// Frontend error object submitted by the browser SDK. Contains the error event message,
 /// type, source URL, line/column numbers, full stack trace, and optional JSON payload.
+///
+/// Field names: lineNumber/columnNumber/stackTrace are camelCase in the Go schema;
+/// override the snake_case naming convention to match.
 /// </summary>
 public record ErrorObjectInput(
     string Event,
     string Type,
     string Url,
     string Source,
-    int LineNumber,
-    int ColumnNumber,
-    List<StackFrameInput?> StackTrace,
+    [property: GraphQLName("lineNumber")] int LineNumber,
+    [property: GraphQLName("columnNumber")] int ColumnNumber,
+    [property: GraphQLName("stackTrace")] List<StackFrameInput?> StackTrace,
     DateTime Timestamp,
     string? Payload);
 
@@ -41,7 +49,9 @@ public record ServiceInput(
 
 /// <summary>
 /// Backend error submitted by a server-side SDK. Includes distributed tracing context
-/// (TraceId, SpanId), service identity, and the error's environment.
+/// (TraceId, SpanId), service identity, and the error's environment. The Go schema's
+/// BackendErrorObjectInput uses mixed casing: most fields are snake_case, `stackTrace`
+/// is camelCase.
 /// </summary>
 public record BackendErrorObjectInput(
     string? SessionSecureId,
@@ -53,7 +63,7 @@ public record BackendErrorObjectInput(
     string Type,
     string Url,
     string Source,
-    string StackTrace,
+    [property: GraphQLName("stackTrace")] string StackTrace,
     DateTime Timestamp,
     string? Payload,
     ServiceInput Service,

--- a/src/dotnet/src/HoldFast.GraphQL.Public/KafkaProducerAdapter.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/KafkaProducerAdapter.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using HoldFast.GraphQL.Public.InputTypes;
 using HoldFast.Shared.Kafka;
 
@@ -21,25 +22,51 @@ public class KafkaProducerAdapter : IKafkaProducer
         return _producer.ProduceAsync(KafkaTopics.SessionEvents, sessionSecureId, message, ct);
     }
 
-    public Task ProducePushPayloadAsync(string sessionSecureId, long payloadId, string events,
+    public async Task ProducePushPayloadAsync(string sessionSecureId, long payloadId, string events,
         string messages, string resources, string? webSocketEvents,
         List<ErrorObjectInput?> errors, bool? isBeacon, bool? hasSessionUnloaded,
         string? highlightLogs, CancellationToken ct)
     {
-        var message = new
+        // Replay events + supporting payload → SessionEvents topic for the rrweb
+        // chunk processor. This message intentionally only carries (SessionSecureId,
+        // PayloadId, Data) because that's all SessionEventsConsumer reads —
+        // serialize the events string as the Data body.
+        var sessionMsg = new
         {
             SessionSecureId = sessionSecureId,
             PayloadId = payloadId,
-            Events = events,
-            Messages = messages,
-            Resources = resources,
-            WebSocketEvents = webSocketEvents,
-            Errors = errors,
-            IsBeacon = isBeacon,
-            HasSessionUnloaded = hasSessionUnloaded,
-            HighlightLogs = highlightLogs,
+            Data = events,
         };
-        return _producer.ProduceAsync(KafkaTopics.SessionEvents, sessionSecureId, message, ct);
+        await _producer.ProduceAsync(KafkaTopics.SessionEvents, sessionSecureId, sessionMsg, ct);
+
+        // Each frontend error → FrontendErrors topic so FrontendErrorsConsumer can
+        // group them into ClickHouse error_objects. Errors are dropped on the
+        // floor by SessionEventsConsumer; routing them separately is HOL-15's fix.
+        foreach (var err in errors)
+        {
+            if (err is null) continue;
+            var frontendMsg = new
+            {
+                SessionSecureId = sessionSecureId,
+                Event = err.Event,
+                Type = err.Type,
+                Url = err.Url,
+                Source = err.Source,
+                LineNumber = err.LineNumber,
+                ColumnNumber = err.ColumnNumber,
+                StackTrace = JsonSerializer.Serialize(err.StackTrace),
+                Timestamp = err.Timestamp,
+                Payload = err.Payload,
+            };
+            await _producer.ProduceAsync(KafkaTopics.FrontendErrors, sessionSecureId, frontendMsg, ct);
+        }
+
+        // _ = messages; _ = resources; _ = webSocketEvents; _ = isBeacon;
+        // _ = hasSessionUnloaded; _ = highlightLogs;
+        // The remaining fields are stored alongside session events in the Go
+        // pipeline but aren't yet consumed in .NET. Tracked separately under
+        // HoldFast Forensic Ingest MVP — capturing them when the consumer-side
+        // contract is widened.
     }
 
     public Task ProduceBackendErrorAsync(string? projectId, BackendErrorObjectInput error, CancellationToken ct)

--- a/src/dotnet/src/HoldFast.Shared/Kafka/KafkaTopics.cs
+++ b/src/dotnet/src/HoldFast.Shared/Kafka/KafkaTopics.cs
@@ -7,6 +7,7 @@ public static class KafkaTopics
 {
     public const string SessionEvents = "session-events";
     public const string BackendErrors = "backend-errors";
+    public const string FrontendErrors = "frontend-errors";
     public const string Metrics = "metrics";
     public const string Logs = "logs";
     public const string Traces = "traces";

--- a/src/dotnet/src/HoldFast.Worker/FrontendErrorsWorker.cs
+++ b/src/dotnet/src/HoldFast.Worker/FrontendErrorsWorker.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using HoldFast.Data;
+using HoldFast.Data.ClickHouse;
+using HoldFast.Data.ClickHouse.Models;
+using HoldFast.Shared.AlertEvaluation;
+using HoldFast.Shared.ErrorGrouping;
+using HoldFast.Shared.Kafka;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoldFast.Worker;
+
+/// <summary>
+/// Kafka message for frontend errors extracted from a SDK pushPayload.
+/// One message per error in the original payload.errors[] list.
+///
+/// Project ID is resolved on the consumer side from the SessionSecureId — the
+/// SDK's pushPayload doesn't carry an explicit project_id (it's implicit
+/// through the session).
+/// </summary>
+public record FrontendErrorMessage(
+    string SessionSecureId,
+    string Event,
+    string Type,
+    string Url,
+    string Source,
+    int LineNumber,
+    int ColumnNumber,
+    // StackTrace is the JSON-serialized list of frames (matches the format
+    // IErrorGroupingService.GroupErrorAsync expects).
+    string StackTrace,
+    DateTime Timestamp,
+    string? Payload);
+
+/// <summary>
+/// Consumes frontend errors from the SDK pushPayload pipeline and groups them
+/// into ClickHouse error_objects + postgres error_groups via the existing
+/// IErrorGroupingService. Mirrors how ErrorGroupingConsumer handles backend
+/// errors, but resolves projectId via the session.
+/// </summary>
+public class FrontendErrorsConsumer : KafkaConsumerService<FrontendErrorMessage>
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FrontendErrorsConsumer> _logger;
+
+    public FrontendErrorsConsumer(
+        IOptions<KafkaOptions> options,
+        IServiceScopeFactory scopeFactory,
+        ILogger<FrontendErrorsConsumer> logger)
+        : base(options, KafkaTopics.FrontendErrors, "frontend-errors-worker", logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ProcessAsync(string key, FrontendErrorMessage value, CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<HoldFastDbContext>();
+        var groupingService = scope.ServiceProvider.GetRequiredService<IErrorGroupingService>();
+
+        // Frontend errors carry session_secure_id, not project_id — look the
+        // session up to find the project this error belongs to.
+        var session = await db.Sessions
+            .FirstOrDefaultAsync(s => s.SecureId == value.SessionSecureId, ct);
+        if (session is null)
+        {
+            _logger.LogWarning(
+                "Frontend error references unknown session {SecureId} — skipping",
+                value.SessionSecureId);
+            return;
+        }
+
+        var result = await groupingService.GroupErrorAsync(
+            session.ProjectId,
+            value.Event,
+            value.Type,
+            value.StackTrace,
+            value.Timestamp,
+            value.Url,
+            value.Source,
+            value.Payload,
+            environment: null,
+            serviceName: null,
+            serviceVersion: null,
+            sessionId: session.Id,
+            traceExternalId: null,
+            spanId: null,
+            ct);
+
+        _logger.LogInformation(
+            "Frontend error grouped: GroupId={GroupId}, IsNew={IsNew}, Event={Event}, Session={Session}",
+            result.ErrorGroup.Id, result.IsNewGroup, value.Event, value.SessionSecureId);
+
+        // Mirror the row to ClickHouse error_objects so dashboard analytics can
+        // query it. Postgres holds the relational error_groups + error_objects;
+        // ClickHouse is the analytics surface for time-series error queries.
+        var clickhouse = scope.ServiceProvider.GetRequiredService<IClickHouseService>();
+        await clickhouse.WriteErrorObjectsAsync(
+            [new ErrorObjectRowInput
+            {
+                ProjectId = session.ProjectId,
+                ErrorObjectId = (int)result.ErrorObject.Id,
+                ErrorGroupId = (int)result.ErrorGroup.Id,
+                Timestamp = value.Timestamp,
+                Event = value.Event,
+                Type = value.Type,
+                Url = value.Url,
+                Environment = null,
+                OS = null,
+                Browser = null,
+                ServiceName = null,
+                ServiceVersion = null,
+            }],
+            ct);
+
+        // Match ErrorGroupingConsumer: evaluate alerts inline so newly-grouped
+        // errors trigger any subscribed alerts immediately.
+        var alertService = scope.ServiceProvider.GetRequiredService<IAlertEvaluationService>();
+        await alertService.EvaluateErrorAlertsAsync(
+            session.ProjectId, result.ErrorGroup, result.ErrorObject, ct);
+    }
+}
+
+public class FrontendErrorsWorker : BackgroundService
+{
+    private readonly FrontendErrorsConsumer _consumer;
+
+    public FrontendErrorsWorker(FrontendErrorsConsumer consumer) => _consumer = consumer;
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) =>
+        _consumer.ConsumeLoopAsync(stoppingToken);
+}

--- a/src/dotnet/tests/HoldFast.Shared.Tests/Kafka/KafkaTopicsTests.cs
+++ b/src/dotnet/tests/HoldFast.Shared.Tests/Kafka/KafkaTopicsTests.cs
@@ -56,11 +56,18 @@ public class KafkaTopicsTests
         Assert.Equal("alert-evaluation", KafkaTopics.AlertEvaluation);
     }
 
+    [Fact]
+    public void FrontendErrors_MatchesGoBackend()
+    {
+        Assert.Equal("frontend-errors", KafkaTopics.FrontendErrors);
+    }
+
     // ── Format validation ─────────────────────────────────────────────
 
     [Theory]
     [InlineData(nameof(KafkaTopics.SessionEvents))]
     [InlineData(nameof(KafkaTopics.BackendErrors))]
+    [InlineData(nameof(KafkaTopics.FrontendErrors))]
     [InlineData(nameof(KafkaTopics.Metrics))]
     [InlineData(nameof(KafkaTopics.Logs))]
     [InlineData(nameof(KafkaTopics.Traces))]
@@ -78,6 +85,7 @@ public class KafkaTopicsTests
     [Theory]
     [InlineData(nameof(KafkaTopics.SessionEvents))]
     [InlineData(nameof(KafkaTopics.BackendErrors))]
+    [InlineData(nameof(KafkaTopics.FrontendErrors))]
     [InlineData(nameof(KafkaTopics.Metrics))]
     [InlineData(nameof(KafkaTopics.Logs))]
     [InlineData(nameof(KafkaTopics.Traces))]
@@ -94,6 +102,7 @@ public class KafkaTopicsTests
     [Theory]
     [InlineData(nameof(KafkaTopics.SessionEvents))]
     [InlineData(nameof(KafkaTopics.BackendErrors))]
+    [InlineData(nameof(KafkaTopics.FrontendErrors))]
     [InlineData(nameof(KafkaTopics.Metrics))]
     [InlineData(nameof(KafkaTopics.Logs))]
     [InlineData(nameof(KafkaTopics.Traces))]
@@ -113,6 +122,7 @@ public class KafkaTopicsTests
         {
             KafkaTopics.SessionEvents,
             KafkaTopics.BackendErrors,
+            KafkaTopics.FrontendErrors,
             KafkaTopics.Metrics,
             KafkaTopics.Logs,
             KafkaTopics.Traces,
@@ -125,7 +135,7 @@ public class KafkaTopicsTests
     }
 
     [Fact]
-    public void TopicCount_IsEight()
+    public void TopicCount_IsNine()
     {
         // Guard against adding a topic constant without tests
         var fields = typeof(KafkaTopics)
@@ -133,7 +143,7 @@ public class KafkaTopicsTests
             .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
             .ToArray();
 
-        Assert.Equal(8, fields.Length);
+        Assert.Equal(9, fields.Length);
     }
 
     // ── No whitespace or hidden characters ────────────────────────────
@@ -141,6 +151,7 @@ public class KafkaTopicsTests
     [Theory]
     [InlineData(nameof(KafkaTopics.SessionEvents))]
     [InlineData(nameof(KafkaTopics.BackendErrors))]
+    [InlineData(nameof(KafkaTopics.FrontendErrors))]
     [InlineData(nameof(KafkaTopics.Metrics))]
     [InlineData(nameof(KafkaTopics.Logs))]
     [InlineData(nameof(KafkaTopics.Traces))]


### PR DESCRIPTION
## Summary

After [HOL-13](https://yt.brewingcoder.com/issue/HOL-13) and [HOL-14](https://yt.brewingcoder.com/issue/HOL-14) made the SDK's `pushPayload` calls return 200, the embedded `errors[]` array was being **silently dropped**: `KafkaProducerAdapter` serialized the whole bundle onto the SessionEvents topic, but the consumer's record (`SessionSecureId, PayloadId, Data`) only matched the rrweb-chunks shape and ignored everything else.

This PR wires up the missing path: pushPayload errors → Kafka frontend-errors topic → consumer that groups them via the existing `IErrorGroupingService` → postgres `error_groups`/`error_objects` + ClickHouse `error_objects`. Mirrors the Go backend's `processPayload` error pipeline.

## End-to-end verified

`Browser → SDK → public GraphQL → Kafka(frontend-errors) → consumer → postgres+ClickHouse → BrowserSdkIngestTests.Browser_TriggeredError_LandsInClickHouse → PASSES`

## What landed

1. New `KafkaTopics.FrontendErrors` topic.
2. New `FrontendErrorMessage` record (one Kafka message per error in `pushPayload.errors[]`).
3. `KafkaProducerAdapter.ProducePushPayloadAsync`:
   - Still ships the rrweb chunks to `SessionEvents` (unchanged consumer).
   - **Now also fans each non-null error out to `FrontendErrors`.**
4. New `FrontendErrorsConsumer`:
   - Resolves `projectId` from postgres via `SessionSecureId` (frontend errors don't carry an explicit project id).
   - Calls `IErrorGroupingService.GroupErrorAsync` — same dedup pipeline used by `ErrorGroupingConsumer` for backend errors.
   - Mirrors the row to ClickHouse `error_objects` via `WriteErrorObjectsAsync`.
   - Triggers alert evaluation inline.
5. `FrontendErrorsWorker` registered in `Program.cs`.

## Bugs found while wiring this up

These were blocking the pipeline; fixed in this PR:

- **camelCase field names on input types.** `ErrorObjectInput.{lineNumber, columnNumber, stackTrace}` and `StackFrameInput.{functionName, fileName, lineNumber, columnNumber, isEval, isNative}` are camelCase in the Go schema, but `SnakeCaseNamingConvention` was rewriting them to `line_number`, etc. SDK sends camelCase → schema rejected the input → errors stripped before they ever reached the producer. Added `[GraphQLName]` overrides on each affected property. Same fix on `BackendErrorObjectInput.stackTrace`.
- **Wrong column names in `ClickHouseService.WriteErrorObjectsAsync`.** It was inserting into `ErrorObjectID, URL, OS, Event, Type` — but the actual `error_objects` table (from the Go migrations) has `ID, VisitedURL, OSName`, and `Event/Type` live on `error_groups`. Rewrote the `INSERT` to match the real schema.

## Tests

- All **3,037 .NET tests pass** (was 3,032 — added 5 new tests for the FrontendErrors topic).
- `KafkaTopicsTests`: `TopicCount` 8 → 9, new `FrontendErrors_MatchesGoBackend` fact, `InlineData`/`AllTopics_AreUnique` arrays widened.
- HoldFast.E2E `BrowserSdkIngestTests.Browser_TriggeredError_LandsInClickHouse` passes end-to-end.

## Test plan

- [ ] `cd src/dotnet && dotnet test HoldFast.Backend.slnx` — 3,037 / 3,037 pass
- [ ] Rebuild backend image, recreate, run `BrowserSdkIngestTests.Browser_TriggeredError_LandsInClickHouse` — passes
- [ ] Manual sanity: `curl pushPayload(... errors:[{event:"x", lineNumber:1, columnNumber:1, stackTrace:[]}])` → row appears in `SELECT count() FROM error_objects WHERE ProjectID=2` within 5s

Stacks on [#91](https://github.com/BrewingCoder/holdfast/pull/91) (HOL-14, which stacks on HOL-13). Closes [HOL-15](https://yt.brewingcoder.com/issue/HOL-15) and unblocks [HOL-4](https://yt.brewingcoder.com/issue/HOL-4) (last code blocker; HOL-11 + HOL-12 still need their fixes for fresh-stack reproducibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)