### PR TITLE
dotnet/ClickHouse: hosted service to apply migrations on startup (HOL-11)

### DIFF
--- a/infra/docker/backend-dotnet.Dockerfile
+++ b/infra/docker/backend-dotnet.Dockerfile
@@ -40,6 +40,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 WORKDIR /app
 COPY --from=build /app .
 
+# ClickHouse migration files — applied at startup by ClickHouseMigrationService.
+# Disable via ClickHouse__Migrations__Disabled=true when the schema is managed
+# externally (e.g. golang-migrate run by a Helm pre-job).
+COPY src/backend/clickhouse/migrations /app/clickhouse-migrations
+
 # Default port — matches Go backend convention
 ENV ASPNETCORE_URLS=http://+:8082
 EXPOSE 8082

--- a/infra/docker/compose.hobby-dotnet.yml
+++ b/infra/docker/compose.hobby-dotnet.yml
@@ -19,6 +19,8 @@ services:
             - ClickHouse__Database=${CLICKHOUSE_DATABASE:-default}
             - ClickHouse__Username=${CLICKHOUSE_USERNAME:-default}
             - ClickHouse__Password=${CLICKHOUSE_PASSWORD:-}
+            - ClickHouse__Migrations__Path=/app/clickhouse-migrations
+            - ClickHouse__Migrations__Disabled=${CLICKHOUSE_MIGRATIONS_DISABLED:-false}
             - Redis__Configuration=${REDIS_ADDRESS:-redis:6379}
             - Kafka__BootstrapServers=${KAFKA_SERVERS:-kafka:9092}
             - Storage__Type=filesystem

--- a/src/dotnet/src/HoldFast.Api/Program.cs
+++ b/src/dotnet/src/HoldFast.Api/Program.cs
@@ -131,6 +131,13 @@ builder.Services.Configure<ClickHouseOptions>(
     builder.Configuration.GetSection("ClickHouse"));
 builder.Services.AddSingleton<IClickHouseService, ClickHouseService>();
 
+// Migration runner — applies src/backend/clickhouse/migrations/*.up.sql at
+// startup, idempotently. Disable via ClickHouse__Migrations__Disabled=true
+// when the schema is managed externally (Helm pre-job, golang-migrate, etc).
+builder.Services.Configure<ClickHouseMigrationOptions>(
+    builder.Configuration.GetSection("ClickHouse:Migrations"));
+builder.Services.AddHostedService<ClickHouseMigrationService>();
+
 // ── Storage ───────────────────────────────────────────────────────────
 builder.Services.Configure<StorageOptions>(
     builder.Configuration.GetSection("Storage"));

--- a/src/dotnet/src/HoldFast.Api/Program.cs
+++ b/src/dotnet/src/HoldFast.Api/Program.cs
@@ -162,6 +162,8 @@ if (runtime.IsWorker())
     builder.Services.AddHostedService<SessionEventsWorker>();
     builder.Services.AddSingleton<ErrorGroupingConsumer>();
     builder.Services.AddHostedService<ErrorGroupingWorker>();
+    builder.Services.AddSingleton<FrontendErrorsConsumer>();
+    builder.Services.AddHostedService<FrontendErrorsWorker>();
     builder.Services.AddSingleton<MetricsConsumer>();
     builder.Services.AddHostedService<MetricsWorker>();
     builder.Services.AddSingleton<LogIngestionConsumer>();

--- a/src/dotnet/src/HoldFast.Data.ClickHouse/ClickHouseMigrationService.cs
+++ b/src/dotnet/src/HoldFast.Data.ClickHouse/ClickHouseMigrationService.cs
@@ -1,0 +1,214 @@
+using ClickHouse.Client.ADO;
+using ClickHouse.Client.Utility;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoldFast.Data.ClickHouse;
+
+/// <summary>
+/// Configuration for the ClickHouse migrations runner.
+/// </summary>
+public class ClickHouseMigrationOptions
+{
+    /// <summary>
+    /// Filesystem path to the directory containing *.up.sql migration files.
+    /// In the Docker image these are copied to /app/clickhouse-migrations.
+    /// Locally (e.g. during tests) point this at src/backend/clickhouse/migrations.
+    /// Set to empty/null to disable migrations (e.g. when an external system manages the schema).
+    /// </summary>
+    public string Path { get; set; } = "/app/clickhouse-migrations";
+
+    /// <summary>
+    /// Skip running migrations. Useful when the schema is managed externally
+    /// (production deployments using golang-migrate, ops-managed Helm pre-jobs, etc).
+    /// </summary>
+    public bool Disabled { get; set; }
+}
+
+/// <summary>
+/// Runs ClickHouse SQL migrations from a directory at startup, idempotently.
+///
+/// Schema parity with the Go backend's golang-migrate runner: tracks applied
+/// versions in a `schema_migrations(version Int64, dirty Bool)` table so the
+/// existing migration files can be shared between Go and .NET deployments
+/// without divergence.
+///
+/// Replaces the manual `for f in *.up.sql; do clickhouse-client -i $f` step
+/// that fresh stacks otherwise required (HOL-11).
+/// </summary>
+public class ClickHouseMigrationService : IHostedService
+{
+    private readonly ClickHouseOptions _chOptions;
+    private readonly ClickHouseMigrationOptions _options;
+    private readonly ILogger<ClickHouseMigrationService> _logger;
+
+    public ClickHouseMigrationService(
+        IOptions<ClickHouseOptions> chOptions,
+        IOptions<ClickHouseMigrationOptions> options,
+        ILogger<ClickHouseMigrationService> logger)
+    {
+        _chOptions = chOptions.Value;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_options.Disabled)
+        {
+            _logger.LogInformation("ClickHouse migrations: disabled by configuration, skipping");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(_options.Path) || !Directory.Exists(_options.Path))
+        {
+            _logger.LogWarning(
+                "ClickHouse migrations: directory {Path} not found, skipping. " +
+                "Set ClickHouse:Migrations:Path or mount the migrations folder.",
+                _options.Path);
+            return;
+        }
+
+        await using var conn = new ClickHouseConnection(_chOptions.GetConnectionString(readOnly: false));
+        await conn.OpenAsync(cancellationToken);
+
+        await EnsureMigrationsTableAsync(conn, cancellationToken);
+        var applied = await GetAppliedVersionsAsync(conn, cancellationToken);
+
+        var files = Directory.GetFiles(_options.Path, "*.up.sql")
+            .OrderBy(f => Path.GetFileName(f), StringComparer.Ordinal)
+            .ToList();
+
+        var appliedCount = 0;
+        foreach (var file in files)
+        {
+            var version = ParseVersion(Path.GetFileName(file));
+            if (version is null) continue; // not a migration we recognize
+            if (applied.Contains(version.Value)) continue;
+
+            await ApplyMigrationAsync(conn, version.Value, file, cancellationToken);
+            appliedCount++;
+        }
+
+        _logger.LogInformation(
+            "ClickHouse migrations: {Applied} applied, {Total} total, {AlreadyApplied} already-applied",
+            appliedCount, files.Count, applied.Count);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static async Task EnsureMigrationsTableAsync(ClickHouseConnection conn, CancellationToken ct)
+    {
+        // Schema matches golang-migrate's clickhouse driver so the tracking table
+        // is interchangeable between Go and .NET deployments.
+        const string sql = @"
+            CREATE TABLE IF NOT EXISTS schema_migrations
+            (
+                version Int64,
+                dirty   UInt8,
+                sequence UInt64
+            )
+            ENGINE = TinyLog";
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task<HashSet<long>> GetAppliedVersionsAsync(
+        ClickHouseConnection conn, CancellationToken ct)
+    {
+        // Latest entry per version determines current state; clean (dirty=0)
+        // means the migration completed successfully.
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            SELECT version
+            FROM (
+                SELECT version, argMax(dirty, sequence) AS latest_dirty
+                FROM schema_migrations
+                GROUP BY version
+            )
+            WHERE latest_dirty = 0";
+        using var reader = await cmd.ExecuteReaderAsync(ct);
+        var set = new HashSet<long>();
+        while (await reader.ReadAsync(ct))
+            set.Add(Convert.ToInt64(reader.GetValue(0)));
+        return set;
+    }
+
+    private async Task ApplyMigrationAsync(
+        ClickHouseConnection conn, long version, string file, CancellationToken ct)
+    {
+        var name = Path.GetFileName(file);
+        _logger.LogInformation("ClickHouse migration: applying {Version} {Name}", version, name);
+
+        var sql = await File.ReadAllTextAsync(file, ct);
+
+        // Mark dirty before running so a partial failure leaves a visible
+        // trail. INSERT-only — golang-migrate's pattern, since TinyLog
+        // (and other Log-family engines) doesn't support mutations.
+        await RecordVersionAsync(conn, version, dirty: true, ct);
+
+        // Migration files contain semicolon-separated statements; split on
+        // top-level semicolons (rough but matches what golang-migrate does for
+        // the same files — these don't contain string literals with embedded ";").
+        foreach (var statement in SplitStatements(sql))
+        {
+            var trimmed = statement.Trim();
+            if (string.IsNullOrEmpty(trimmed)) continue;
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = trimmed;
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        // Mark clean — newer sequence wins in the latest-per-version query.
+        await RecordVersionAsync(conn, version, dirty: false, ct);
+    }
+
+    private static async Task RecordVersionAsync(
+        ClickHouseConnection conn, long version, bool dirty, CancellationToken ct)
+    {
+        using var ins = conn.CreateCommand();
+        ins.CommandText =
+            "INSERT INTO schema_migrations (version, dirty, sequence) VALUES " +
+            "({v:Int64}, {d:UInt8}, {s:UInt64})";
+        ins.AddParameter("v", version);
+        ins.AddParameter("d", dirty ? (byte)1 : (byte)0);
+        ins.AddParameter("s", (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        await ins.ExecuteNonQueryAsync(ct);
+    }
+
+    private static long? ParseVersion(string filename)
+    {
+        // Migration filenames look like "000001_create_logs_table.up.sql" — the
+        // numeric prefix is the version.
+        var idx = filename.IndexOf('_');
+        if (idx <= 0) return null;
+        return long.TryParse(filename[..idx], out var n) ? n : null;
+    }
+
+    /// <summary>
+    /// Splits a migration body on top-level semicolons. ClickHouse migration
+    /// files don't typically contain string literals with embedded semicolons,
+    /// so this simple split is sufficient (and matches how golang-migrate handles
+    /// the same files for parity).
+    /// </summary>
+    private static IEnumerable<string> SplitStatements(string sql)
+    {
+        var current = new System.Text.StringBuilder();
+        foreach (var line in sql.Split('\n'))
+        {
+            var stripped = line.TrimStart();
+            // Skip line comments
+            if (stripped.StartsWith("--")) continue;
+            current.AppendLine(line);
+        }
+        var cleaned = current.ToString();
+
+        // Split on ';' followed by whitespace/newline, keep statements
+        var parts = cleaned.Split(';');
+        foreach (var p in parts)
+            if (!string.IsNullOrWhiteSpace(p))
+                yield return p;
+    }
+}

--- a/src/dotnet/src/HoldFast.Data.ClickHouse/ClickHouseService.cs
+++ b/src/dotnet/src/HoldFast.Data.ClickHouse/ClickHouseService.cs
@@ -969,23 +969,25 @@ public class ClickHouseService : IClickHouseService, IDisposable
 
         foreach (var e in list)
         {
+            // Column names match the actual error_objects table from the Go
+            // migrations (000xxx_create_errors_table.up.sql): ID (not
+            // ErrorObjectID), VisitedURL (not URL), OSName (not OS).
+            // Event/Type live on error_groups, not error_objects.
             var sql =
-                "INSERT INTO error_objects (ProjectID, ErrorObjectID, ErrorGroupID, " +
-                "Timestamp, Event, Type, URL, Environment, OS, Browser, " +
+                "INSERT INTO error_objects (ProjectID, ID, ErrorGroupID, " +
+                "Timestamp, VisitedURL, Environment, OSName, Browser, " +
                 "ServiceName, ServiceVersion) " +
-                "VALUES ({projectId:Int32}, {errorObjectId:Int32}, {errorGroupId:Int32}, " +
-                "{ts:DateTime64(9)}, {event:String}, {type:String}, {url:String}, " +
+                "VALUES ({projectId:Int32}, {errorObjectId:Int64}, {errorGroupId:Int64}, " +
+                "{ts:DateTime64(6)}, {url:String}, " +
                 "{env:String}, {os:String}, {browser:String}, " +
                 "{serviceName:String}, {serviceVersion:String})";
 
             using var cmd = _conn.CreateCommand();
             cmd.CommandText = sql;
             cmd.AddParameter("projectId", e.ProjectId);
-            cmd.AddParameter("errorObjectId", e.ErrorObjectId);
-            cmd.AddParameter("errorGroupId", e.ErrorGroupId);
+            cmd.AddParameter("errorObjectId", (long)e.ErrorObjectId);
+            cmd.AddParameter("errorGroupId", (long)e.ErrorGroupId);
             cmd.AddParameter("ts", e.Timestamp);
-            cmd.AddParameter("event", e.Event ?? "");
-            cmd.AddParameter("type", e.Type ?? "");
             cmd.AddParameter("url", e.Url ?? "");
             cmd.AddParameter("env", e.Environment ?? "");
             cmd.AddParameter("os", e.OS ?? "");

--- a/src/dotnet/src/HoldFast.Data.ClickHouse/HoldFast.Data.ClickHouse.csproj
+++ b/src/dotnet/src/HoldFast.Data.ClickHouse/HoldFast.Data.ClickHouse.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="ClickHouse.Client" Version="7.14.0" />
     <PackageReference Include="Dapper" Version="2.1.72" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
   </ItemGroup>

--- a/src/dotnet/src/HoldFast.GraphQL.Public/InputTypes/ErrorInputs.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/InputTypes/ErrorInputs.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using HotChocolate;
 
 namespace HoldFast.GraphQL.Public.InputTypes;
 
@@ -6,29 +7,36 @@ namespace HoldFast.GraphQL.Public.InputTypes;
 /// A single frame in an error stack trace. Maps to one line in a JS/TS stack trace.
 /// IsEval/IsNative indicate the execution context. `args` holds opaque
 /// argument values (matches Go schema's `args: [Any]`).
+///
+/// Field names use [GraphQLName] to expose camelCase to clients — the Go schema
+/// (and the SDKs generated against it) uses camelCase here even though the
+/// global convention is snake_case. Mixed casing in the upstream contract.
 /// </summary>
 public record StackFrameInput(
-    string? FunctionName,
+    [property: GraphQLName("functionName")] string? FunctionName,
     List<JsonElement?>? Args,
-    string? FileName,
-    int? LineNumber,
-    int? ColumnNumber,
-    bool? IsEval,
-    bool? IsNative,
+    [property: GraphQLName("fileName")] string? FileName,
+    [property: GraphQLName("lineNumber")] int? LineNumber,
+    [property: GraphQLName("columnNumber")] int? ColumnNumber,
+    [property: GraphQLName("isEval")] bool? IsEval,
+    [property: GraphQLName("isNative")] bool? IsNative,
     string? Source);
 
 /// <summary>
 /// Frontend error object submitted by the browser SDK. Contains the error event message,
 /// type, source URL, line/column numbers, full stack trace, and optional JSON payload.
+///
+/// Field names: lineNumber/columnNumber/stackTrace are camelCase in the Go schema;
+/// override the snake_case naming convention to match.
 /// </summary>
 public record ErrorObjectInput(
     string Event,
     string Type,
     string Url,
     string Source,
-    int LineNumber,
-    int ColumnNumber,
-    List<StackFrameInput?> StackTrace,
+    [property: GraphQLName("lineNumber")] int LineNumber,
+    [property: GraphQLName("columnNumber")] int ColumnNumber,
+    [property: GraphQLName("stackTrace")] List<StackFrameInput?> StackTrace,
     DateTime Timestamp,
     string? Payload);
 
@@ -41,7 +49,9 @@ public record ServiceInput(
 
 /// <summary>
 /// Backend error submitted by a server-side SDK. Includes distributed tracing context
-/// (TraceId, SpanId), service identity, and the error's environment.
+/// (TraceId, SpanId), service identity, and the error's environment. The Go schema's
+/// BackendErrorObjectInput uses mixed casing: most fields are snake_case, `stackTrace`
+/// is camelCase.
 /// </summary>
 public record BackendErrorObjectInput(
     string? SessionSecureId,
@@ -53,7 +63,7 @@ public record BackendErrorObjectInput(
     string Type,
     string Url,
     string Source,
-    string StackTrace,
+    [property: GraphQLName("stackTrace")] string StackTrace,
     DateTime Timestamp,
     string? Payload,
     ServiceInput Service,

--- a/src/dotnet/src/HoldFast.GraphQL.Public/KafkaProducerAdapter.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/KafkaProducerAdapter.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using HoldFast.GraphQL.Public.InputTypes;
 using HoldFast.Shared.Kafka;
 
@@ -21,25 +22,51 @@ public class KafkaProducerAdapter : IKafkaProducer
         return _producer.ProduceAsync(KafkaTopics.SessionEvents, sessionSecureId, message, ct);
     }
 
-    public Task ProducePushPayloadAsync(string sessionSecureId, long payloadId, string events,
+    public async Task ProducePushPayloadAsync(string sessionSecureId, long payloadId, string events,
         string messages, string resources, string? webSocketEvents,
         List<ErrorObjectInput?> errors, bool? isBeacon, bool? hasSessionUnloaded,
         string? highlightLogs, CancellationToken ct)
     {
-        var message = new
+        // Replay events + supporting payload → SessionEvents topic for the rrweb
+        // chunk processor. This message intentionally only carries (SessionSecureId,
+        // PayloadId, Data) because that's all SessionEventsConsumer reads —
+        // serialize the events string as the Data body.
+        var sessionMsg = new
         {
             SessionSecureId = sessionSecureId,
             PayloadId = payloadId,
-            Events = events,
-            Messages = messages,
-            Resources = resources,
-            WebSocketEvents = webSocketEvents,
-            Errors = errors,
-            IsBeacon = isBeacon,
-            HasSessionUnloaded = hasSessionUnloaded,
-            HighlightLogs = highlightLogs,
+            Data = events,
         };
-        return _producer.ProduceAsync(KafkaTopics.SessionEvents, sessionSecureId, message, ct);
+        await _producer.ProduceAsync(KafkaTopics.SessionEvents, sessionSecureId, sessionMsg, ct);
+
+        // Each frontend error → FrontendErrors topic so FrontendErrorsConsumer can
+        // group them into ClickHouse error_objects. Errors are dropped on the
+        // floor by SessionEventsConsumer; routing them separately is HOL-15's fix.
+        foreach (var err in errors)
+        {
+            if (err is null) continue;
+            var frontendMsg = new
+            {
+                SessionSecureId = sessionSecureId,
+                Event = err.Event,
+                Type = err.Type,
+                Url = err.Url,
+                Source = err.Source,
+                LineNumber = err.LineNumber,
+                ColumnNumber = err.ColumnNumber,
+                StackTrace = JsonSerializer.Serialize(err.StackTrace),
+                Timestamp = err.Timestamp,
+                Payload = err.Payload,
+            };
+            await _producer.ProduceAsync(KafkaTopics.FrontendErrors, sessionSecureId, frontendMsg, ct);
+        }
+
+        // _ = messages; _ = resources; _ = webSocketEvents; _ = isBeacon;
+        // _ = hasSessionUnloaded; _ = highlightLogs;
+        // The remaining fields are stored alongside session events in the Go
+        // pipeline but aren't yet consumed in .NET. Tracked separately under
+        // HoldFast Forensic Ingest MVP — capturing them when the consumer-side
+        // contract is widened.
     }
 
     public Task ProduceBackendErrorAsync(string? projectId, BackendErrorObjectInput error, CancellationToken ct)

--- a/src/dotnet/src/HoldFast.Shared/Kafka/KafkaTopics.cs
+++ b/src/dotnet/src/HoldFast.Shared/Kafka/KafkaTopics.cs
@@ -7,6 +7,7 @@ public static class KafkaTopics
 {
     public const string SessionEvents = "session-events";
     public const string BackendErrors = "backend-errors";
+    public const string FrontendErrors = "frontend-errors";
     public const string Metrics = "metrics";
     public const string Logs = "logs";
     public const string Traces = "traces";

--- a/src/dotnet/src/HoldFast.Worker/FrontendErrorsWorker.cs
+++ b/src/dotnet/src/HoldFast.Worker/FrontendErrorsWorker.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using HoldFast.Data;
+using HoldFast.Data.ClickHouse;
+using HoldFast.Data.ClickHouse.Models;
+using HoldFast.Shared.AlertEvaluation;
+using HoldFast.Shared.ErrorGrouping;
+using HoldFast.Shared.Kafka;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoldFast.Worker;
+
+/// <summary>
+/// Kafka message for frontend errors extracted from a SDK pushPayload.
+/// One message per error in the original payload.errors[] list.
+///
+/// Project ID is resolved on the consumer side from the SessionSecureId — the
+/// SDK's pushPayload doesn't carry an explicit project_id (it's implicit
+/// through the session).
+/// </summary>
+public record FrontendErrorMessage(
+    string SessionSecureId,
+    string Event,
+    string Type,
+    string Url,
+    string Source,
+    int LineNumber,
+    int ColumnNumber,
+    // StackTrace is the JSON-serialized list of frames (matches the format
+    // IErrorGroupingService.GroupErrorAsync expects).
+    string StackTrace,
+    DateTime Timestamp,
+    string? Payload);
+
+/// <summary>
+/// Consumes frontend errors from the SDK pushPayload pipeline and groups them
+/// into ClickHouse error_objects + postgres error_groups via the existing
+/// IErrorGroupingService. Mirrors how ErrorGroupingConsumer handles backend
+/// errors, but resolves projectId via the session.
+/// </summary>
+public class FrontendErrorsConsumer : KafkaConsumerService<FrontendErrorMessage>
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<FrontendErrorsConsumer> _logger;
+
+    public FrontendErrorsConsumer(
+        IOptions<KafkaOptions> options,
+        IServiceScopeFactory scopeFactory,
+        ILogger<FrontendErrorsConsumer> logger)
+        : base(options, KafkaTopics.FrontendErrors, "frontend-errors-worker", logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ProcessAsync(string key, FrontendErrorMessage value, CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<HoldFastDbContext>();
+        var groupingService = scope.ServiceProvider.GetRequiredService<IErrorGroupingService>();
+
+        // Frontend errors carry session_secure_id, not project_id — look the
+        // session up to find the project this error belongs to.
+        var session = await db.Sessions
+            .FirstOrDefaultAsync(s => s.SecureId == value.SessionSecureId, ct);
+        if (session is null)
+        {
+            _logger.LogWarning(
+                "Frontend error references unknown session {SecureId} — skipping",
+                value.SessionSecureId);
+            return;
+        }
+
+        var result = await groupingService.GroupErrorAsync(
+            session.ProjectId,
+            value.Event,
+            value.Type,
+            value.StackTrace,
+            value.Timestamp,
+            value.Url,
+            value.Source,
+            value.Payload,
+            environment: null,
+            serviceName: null,
+            serviceVersion: null,
+            sessionId: session.Id,
+            traceExternalId: null,
+            spanId: null,
+            ct);
+
+        _logger.LogInformation(
+            "Frontend error grouped: GroupId={GroupId}, IsNew={IsNew}, Event={Event}, Session={Session}",
+            result.ErrorGroup.Id, result.IsNewGroup, value.Event, value.SessionSecureId);
+
+        // Mirror the row to ClickHouse error_objects so dashboard analytics can
+        // query it. Postgres holds the relational error_groups + error_objects;
+        // ClickHouse is the analytics surface for time-series error queries.
+        var clickhouse = scope.ServiceProvider.GetRequiredService<IClickHouseService>();
+        await clickhouse.WriteErrorObjectsAsync(
+            [new ErrorObjectRowInput
+            {
+                ProjectId = session.ProjectId,
+                ErrorObjectId = (int)result.ErrorObject.Id,
+                ErrorGroupId = (int)result.ErrorGroup.Id,
+                Timestamp = value.Timestamp,
+                Event = value.Event,
+                Type = value.Type,
+                Url = value.Url,
+                Environment = null,
+                OS = null,
+                Browser = null,
+                ServiceName = null,
+                ServiceVersion = null,
+            }],
+            ct);
+
+        // Match ErrorGroupingConsumer: evaluate alerts inline so newly-grouped
+        // errors trigger any subscribed alerts immediately.
+        var alertService = scope.ServiceProvider.GetRequiredService<IAlertEvaluationService>();
+        await alertService.EvaluateErrorAlertsAsync(
+            session.ProjectId, result.ErrorGroup, result.ErrorObject, ct);
+    }
+}
+
+public class FrontendErrorsWorker : BackgroundService
+{
+    private readonly FrontendErrorsConsumer _consumer;
+
+    public FrontendErrorsWorker(FrontendErrorsConsumer consumer) => _consumer = consumer;
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken) =>
+        _consumer.ConsumeLoopAsync(stoppingToken);
+}

--- a/src/dotnet/tests/HoldFast.Shared.Tests/Kafka/KafkaTopicsTests.cs
+++ b/src/dotnet/tests/HoldFast.Shared.Tests/Kafka/KafkaTopicsTests.cs
@@ -56,11 +56,18 @@ public class KafkaTopicsTests
         Assert.Equal("alert-evaluation", KafkaTopics.AlertEvaluation);
     }
 
+    [Fact]
+    public void FrontendErrors_MatchesGoBackend()
+    {
+        Assert.Equal("frontend-errors", KafkaTopics.FrontendErrors);
+    }
+
     // ── Format validation ─────────────────────────────────────────────
 
     [Theory]
     [InlineData(nameof(KafkaTopics.SessionEvents))]
     [InlineData(nameof(KafkaTopics.BackendErrors))]
+    [InlineData(nameof(KafkaTopics.FrontendErrors))]
     [InlineData(nameof(KafkaTopics.Metrics))]
     [InlineData(nameof(KafkaTopics.Logs))]
     [InlineData(nameof(KafkaTopics.Traces))]
@@ -78,6 +85,7 @@ public class KafkaTopicsTests
     [Theory]
     [InlineData(nameof(KafkaTopics.SessionEvents))]
     [InlineData(nameof(KafkaTopics.BackendErrors))]
+    [InlineData(nameof(KafkaTopics.FrontendErrors))]
     [InlineData(nameof(KafkaTopics.Metrics))]
     [InlineData(nameof(KafkaTopics.Logs))]
     [InlineData(nameof(KafkaTopics.Traces))]
@@ -94,6 +102,7 @@ public class KafkaTopicsTests
     [Theory]
     [InlineData(nameof(KafkaTopics.SessionEvents))]
     [InlineData(nameof(KafkaTopics.BackendErrors))]
+    [InlineData(nameof(KafkaTopics.FrontendErrors))]
     [InlineData(nameof(KafkaTopics.Metrics))]
     [InlineData(nameof(KafkaTopics.Logs))]
     [InlineData(nameof(KafkaTopics.Traces))]
@@ -113,6 +122,7 @@ public class KafkaTopicsTests
         {
             KafkaTopics.SessionEvents,
             KafkaTopics.BackendErrors,
+            KafkaTopics.FrontendErrors,
             KafkaTopics.Metrics,
             KafkaTopics.Logs,
             KafkaTopics.Traces,
@@ -125,7 +135,7 @@ public class KafkaTopicsTests
     }
 
     [Fact]
-    public void TopicCount_IsEight()
+    public void TopicCount_IsNine()
     {
         // Guard against adding a topic constant without tests
         var fields = typeof(KafkaTopics)
@@ -133,7 +143,7 @@ public class KafkaTopicsTests
             .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
             .ToArray();
 
-        Assert.Equal(8, fields.Length);
+        Assert.Equal(9, fields.Length);
     }
 
     // ── No whitespace or hidden characters ────────────────────────────
@@ -141,6 +151,7 @@ public class KafkaTopicsTests
     [Theory]
     [InlineData(nameof(KafkaTopics.SessionEvents))]
     [InlineData(nameof(KafkaTopics.BackendErrors))]
+    [InlineData(nameof(KafkaTopics.FrontendErrors))]
     [InlineData(nameof(KafkaTopics.Metrics))]
     [InlineData(nameof(KafkaTopics.Logs))]
     [InlineData(nameof(KafkaTopics.Traces))]


### PR DESCRIPTION
## Summary

Adds `ClickHouseMigrationService` — an `IHostedService` that applies the existing `src/backend/clickhouse/migrations/*.up.sql` files at .NET backend startup, idempotently. Before this PR, a fresh `docker compose up` left ClickHouse with zero tables and every worker that touched it crashed in a tight loop with `Table default.X does not exist`.

## Approach

- Reads migration files from a configurable path (default `/app/clickhouse-migrations`, copied into the image by the Dockerfile).
- Tracks applied versions in `schema_migrations(version Int64, dirty UInt8, sequence UInt64) ENGINE TinyLog` — same layout as golang-migrate's clickhouse driver, so a deployment can mix Go and .NET migration runs without divergence.
- INSERT-only state machine: TinyLog can't mutate, so each version transition appends a row. Current state per version is `argMax(dirty, sequence)` — a clean entry after a dirty one means the migration completed.
- Registered in `Program.cs` before any worker hosted service so workers don't race the schema. `IHostedService.StartAsync` runs sequentially.

## Disable knob

`ClickHouse__Migrations__Disabled=true` bypasses the runner when the schema is managed externally (Helm pre-job, golang-migrate from CI, ops-managed pipelines).

## Verified end-to-end

- `DROP DATABASE default; CREATE DATABASE default;` → recreate backend → 146 migrations apply, 86 tables created, all consumers start cleanly.
- Restart backend → log line: `ClickHouse migrations: 0 applied, 146 total, 146 already-applied` (idempotent).
- All 3,037 existing .NET tests still pass.

## Test plan

- [ ] Fresh `docker compose up` (no prior ClickHouse data) → backend log shows `ClickHouse migrations: 146 applied, 146 total, 0 already-applied`
- [ ] `docker exec clickhouse clickhouse-client -q "SELECT count() FROM system.tables WHERE database='default'"` → 86
- [ ] `docker compose restart backend` → log shows `0 applied, 146 already-applied`
- [ ] `cd src/dotnet && dotnet test HoldFast.Backend.slnx` → 3,037 / 3,037 pass

Stacks on [#92](https://github.com/BrewingCoder/holdfast/pull/92) (HOL-15). Closes [HOL-11](https://yt.brewingcoder.com/issue/HOL-11). One of two remaining infra blockers for [HOL-4](https://yt.brewingcoder.com/issue/HOL-4) (the other is HOL-12 Kafka topic creation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)