### PR TITLE
ci: catch stale committed GraphQL types (HOL-9)

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -46,6 +46,21 @@ jobs:
           yarn turbo run build --filter='rrweb...'
           yarn turbo run build --filter='@rrweb/*' --filter='!@rrweb/web-extension'
 
+      # HOL-9: catch stale committed GraphQL types. Regenerate from the .graphqls
+      # schema and .gql operations and fail if the working tree differs from what's
+      # committed. We hit this in HOL-13 — the committed schemas.tsx referenced
+      # phone_home_contact_allowed which the schema no longer exposed, and local
+      # tsc was happy until the Docker build (which always regenerates) caught it.
+      - name: Verify GraphQL types are in sync
+        run: |
+          yarn workspace @holdfast-io/frontend codegen
+          if ! git diff --exit-code -- src/frontend/src/graph/generated/; then
+            echo ""
+            echo "::error::Generated GraphQL types in src/frontend/src/graph/generated/ are stale."
+            echo "Run 'yarn workspace @holdfast-io/frontend codegen' locally and commit the changes."
+            exit 1
+          fi
+
       - name: TypeScript check
         run: yarn workspace @holdfast-io/frontend types:check
 


### PR DESCRIPTION
## Summary

Adds a CI step to ci-frontend.yml that runs `yarn codegen` then `git diff --exit-code` against `src/frontend/src/graph/generated/`. Fails the PR if the committed types don't match what codegen would produce from the current schema + .gql operations.

## Why

We hit this exactly once during HOL-13: the committed `schemas.tsx` referenced a `phone_home_contact_allowed` field that the schema had already removed, but `tsc` on the developer machine was happy because it used the stale types. The Docker build (which always runs codegen fresh) finally caught it after a 12-minute round trip. Cheap, deterministic CI guard prevents the entire class.

Closes [HOL-9](https://yt.brewingcoder.com/issue/HOL-9).

## Test plan

- [ ] PR triggers CI; new step `Verify GraphQL types are in sync` runs and passes (since types are currently in sync after HOL-13).
- [ ] To verify the guard works: temporarily edit `src/frontend/src/graph/generated/schemas.tsx` on a branch, push, observe CI failure with the error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)