### PR TITLE
infra: swap hobby PG to timescaledb-ha + bump CH max_concurrent_queries to 50 (HOL-35)

### DIFF
--- a/infra/docker/.env.example
+++ b/infra/docker/.env.example
@@ -21,7 +21,7 @@ COMPOSE_PATH_SEPARATOR=:
 
 # Infra dependencies — pinned for reproducibility.
 CLICKHOUSE_IMAGE_NAME=clickhouse/clickhouse-server:24.3.15.72-alpine
-POSTGRES_IMAGE_NAME=ankane/pgvector:v0.5.1
+POSTGRES_IMAGE_NAME=timescale/timescaledb-ha:pg16
 # OTEL collector image vars removed — HOL-21 dropped the collector container.
 # Backend hosts the OTLP receiver at /otel/v1/{logs,traces,metrics}.
 

--- a/infra/docker/backend-dotnet.Dockerfile
+++ b/infra/docker/backend-dotnet.Dockerfile
@@ -77,11 +77,17 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS backend-buil
 
 WORKDIR /src
 
-# Copy project files first for layer caching
+# Copy project files first for layer caching. Every project in the slnx
+# must be listed here — `dotnet restore` walks the project graph and needs
+# each .csproj to exist on disk before generating the assets file. Adding
+# a new project means adding a new line here (HOL-25 added Analytics,
+# HOL-26 added Data.Postgres).
 COPY src/dotnet/HoldFast.Backend.slnx .
+COPY src/dotnet/src/HoldFast.Analytics/HoldFast.Analytics.csproj src/HoldFast.Analytics/
 COPY src/dotnet/src/HoldFast.Api/HoldFast.Api.csproj src/HoldFast.Api/
 COPY src/dotnet/src/HoldFast.Data/HoldFast.Data.csproj src/HoldFast.Data/
 COPY src/dotnet/src/HoldFast.Data.ClickHouse/HoldFast.Data.ClickHouse.csproj src/HoldFast.Data.ClickHouse/
+COPY src/dotnet/src/HoldFast.Data.Postgres/HoldFast.Data.Postgres.csproj src/HoldFast.Data.Postgres/
 COPY src/dotnet/src/HoldFast.Domain/HoldFast.Domain.csproj src/HoldFast.Domain/
 COPY src/dotnet/src/HoldFast.GraphQL.Private/HoldFast.GraphQL.Private.csproj src/HoldFast.GraphQL.Private/
 COPY src/dotnet/src/HoldFast.GraphQL.Public/HoldFast.GraphQL.Public.csproj src/HoldFast.GraphQL.Public/

--- a/infra/docker/compose.yml
+++ b/infra/docker/compose.yml
@@ -15,7 +15,11 @@ services:
     postgres:
         logging: *local-logging
         container_name: postgres
-        # a postgres image with pgvector installed
+        # HOL-35: timescale/timescaledb-ha bundles TimescaleDB + pgvector +
+        # pg_partman, replacing ankane/pgvector. Same PG 16 underneath so
+        # the data volume is drop-in reusable; first start activates the
+        # extra extensions once HOL-26's 0003_install_extensions migration
+        # runs (or analyst opens psql + CREATE EXTENSION manually).
         image: ${POSTGRES_IMAGE_NAME}
         restart: on-failure
         ports:
@@ -23,7 +27,11 @@ services:
         environment:
             POSTGRES_HOST_AUTH_METHOD: trust
         volumes:
-            - postgres-data:/var/lib/postgresql/data
+            # HOL-35: timescale/timescaledb-ha lays out its data dir at
+            # /home/postgres/pgdata/data, not the upstream PG default. If
+            # you swap to a different PG image (e.g. plain postgres:16 or
+            # ankane/pgvector), revert to /var/lib/postgresql/data.
+            - postgres-data:/home/postgres/pgdata/data
             - ../../tools/scripts/migrations/init.sql:/root/init.sql
         healthcheck:
             test: ['CMD-SHELL', 'pg_isready -U postgres']

--- a/infra/docker/config.xml
+++ b/infra/docker/config.xml
@@ -54,10 +54,15 @@
     <background_common_pool_size>4</background_common_pool_size>
     <background_move_pool_size>2</background_move_pool_size>
 
-    <!-- Concurrent-query ceilings — single-tenant, no need for 100. -->
-    <max_concurrent_queries>20</max_concurrent_queries>
-    <max_concurrent_insert_queries>10</max_concurrent_insert_queries>
-    <max_concurrent_select_queries>10</max_concurrent_select_queries>
+    <!-- Concurrent-query ceilings. HOL-35: bumped from 20→50 / 10→25 /
+         10→25 after HOL-29 schema-discovery work hit
+         "Too many simultaneous queries" on simple SHOW CREATE TABLE.
+         The backend's six worker hosted services each keep CH busy with
+         small queries; 20 wasn't enough headroom. 50 is still well below
+         the default of 100 but accommodates the actual concurrency. -->
+    <max_concurrent_queries>50</max_concurrent_queries>
+    <max_concurrent_insert_queries>25</max_concurrent_insert_queries>
+    <max_concurrent_select_queries>25</max_concurrent_select_queries>
 
     <!-- Async metrics collection. Default polls every 1s and keeps a
          heavy 120s rollup; on an idle box that's pure noise. -->


### PR DESCRIPTION
## Summary

Two related infra tweaks surfaced during HOL-26 / HOL-29 prep work, plus a Dockerfile fix.

### 1. Hobby PG image: `ankane/pgvector` → `timescale/timescaledb-ha:pg16`

Hobby PG image swaps to bundle TimescaleDB + pgvector + timescaledb_toolkit. The new image enables hypertable partitioning + `drop_chunks` retention for HOL-29's high-volume analytics tables (logs, traces, error_objects, sessions). Apache 2 base + Timescale License community features; AGPL-compatible.

**Volume layout note:** timescaledb-ha lays its data dir at `/home/postgres/pgdata/data`, NOT the upstream `/var/lib/postgresql/data`. Updated the volume mount to match. Anyone swapping back to a different PG image needs to revert that path too — flagged in compose.yml comment.

**One-time data wipe:** the path change means existing dev volumes don't carry forward. DevSeed recreates 5 workspaces + 5 projects on first start (verified). Production deployments would need a `pg_dump`/`restore` migration plan.

### 2. CH `max_concurrent_queries` 20 → 50

HOL-24 set this to 20 to constrain idle. Real workload exceeded it — single `SHOW CREATE TABLE` queries got rejected with "Too many simultaneous queries" during HOL-29 schema-discovery, because the backend's six worker hosted services keep CH busy continuously. 50 is still well below the default of 100. Insert/select sub-caps bumped 10 → 25 each.

### 3. Dockerfile fix (uncovered while live-testing the above)

`backend-dotnet.Dockerfile` only had COPY directives for projects that existed before HOL-25/26. The new `HoldFast.Analytics` and `HoldFast.Data.Postgres` projects were missing from the pre-restore COPY block, so `dotnet restore` couldn't generate their assets files and the publish step failed. Added the two missing lines + a comment reminding future contributors to update this list when adding projects to the slnx.

## Acceptance verified live

- [x] `docker compose up -d` brings up TimescaleDB-HA cleanly with the corrected volume mount
- [x] DevSeed recreates 5 workspaces + 5 projects in the new image
- [x] HOL-26 PG migrations now actually run on backend startup:
      ```
      Analytics PG migration: applying 1 0001_create_analytics_schema.up.sql
      Analytics PG migration: applying 2 0002_create_schema_migrations.up.sql
      Analytics PG migration: applying 3 0003_install_extensions.up.sql
      Analytics PG migrations: 3 applied, 3 total, 0 already-applied
      ```
- [x] `analytics.schema_migrations` populated with versions 1–3, all `dirty=false`
- [x] TimescaleDB 2.26.4 extension active (vs. the NOTICE-no-op in the old image)
- [x] CH `max_concurrent_queries` reads 50 from `system.server_settings`
- [x] Backend `/health` 200; existing CH backend untouched

## Stats

4 files changed, +27 / -8.

Closes [HOL-35](https://yt.brewingcoder.com/issue/HOL-35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)