### PR TITLE
dotnet: PostgresMetricStore + EventFieldStore + AlertStateStore (HOL-33)

### DIFF
--- a/src/dotnet/src/HoldFast.Api/Program.cs
+++ b/src/dotnet/src/HoldFast.Api/Program.cs
@@ -170,6 +170,9 @@ builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresLogStore>();
 builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresTraceStore>();
 builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresSessionAnalyticsStore>();
 builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresErrorAnalyticsStore>();
+builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresMetricStore>();
+builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresEventFieldStore>();
+builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresAlertStateStore>();
 
 var logStoreBackend = builder.Configuration["Storage:Analytics:LogStore"] ?? "clickhouse";
 if (logStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
@@ -217,9 +220,29 @@ else
     builder.Services.AddSingleton<HoldFast.Analytics.IErrorAnalyticsStore>(
         sp => sp.GetRequiredService<ClickHouseService>());
 }
-builder.Services.AddSingleton<HoldFast.Analytics.IMetricStore>(sp => sp.GetRequiredService<ClickHouseService>());
-builder.Services.AddSingleton<HoldFast.Analytics.IEventFieldStore>(sp => sp.GetRequiredService<ClickHouseService>());
-builder.Services.AddSingleton<HoldFast.Analytics.IAlertStateStore>(sp => sp.GetRequiredService<ClickHouseService>());
+var metricStoreBackend = builder.Configuration["Storage:Analytics:MetricStore"] ?? "clickhouse";
+if (metricStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
+    builder.Services.AddSingleton<HoldFast.Analytics.IMetricStore>(
+        sp => sp.GetRequiredService<HoldFast.Data.Postgres.PostgresMetricStore>());
+else
+    builder.Services.AddSingleton<HoldFast.Analytics.IMetricStore>(
+        sp => sp.GetRequiredService<ClickHouseService>());
+
+var eventFieldStoreBackend = builder.Configuration["Storage:Analytics:EventFieldStore"] ?? "clickhouse";
+if (eventFieldStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
+    builder.Services.AddSingleton<HoldFast.Analytics.IEventFieldStore>(
+        sp => sp.GetRequiredService<HoldFast.Data.Postgres.PostgresEventFieldStore>());
+else
+    builder.Services.AddSingleton<HoldFast.Analytics.IEventFieldStore>(
+        sp => sp.GetRequiredService<ClickHouseService>());
+
+var alertStoreBackend = builder.Configuration["Storage:Analytics:AlertStateStore"] ?? "clickhouse";
+if (alertStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
+    builder.Services.AddSingleton<HoldFast.Analytics.IAlertStateStore>(
+        sp => sp.GetRequiredService<HoldFast.Data.Postgres.PostgresAlertStateStore>());
+else
+    builder.Services.AddSingleton<HoldFast.Analytics.IAlertStateStore>(
+        sp => sp.GetRequiredService<ClickHouseService>());
 
 // Migration runner — applies src/backend/clickhouse/migrations/*.up.sql at
 // startup, idempotently. Disable via ClickHouse__Migrations__Disabled=true

--- a/src/dotnet/src/HoldFast.Data.Postgres/Migrations/0050_create_metrics.up.sql
+++ b/src/dotnet/src/HoldFast.Data.Postgres/Migrations/0050_create_metrics.up.sql
@@ -1,0 +1,48 @@
+-- HOL-33: metrics hypertable.
+--
+-- Single consolidated table replacing CH's `metrics_sum` + `metrics` (CH had
+-- a write-side raw table and a read-side MV). For PG we just use one table —
+-- write directly, query directly. Simpler at hobby scale; for higher write
+-- volume a future PR can add a TimescaleDB continuous aggregate.
+--
+-- Tags are JSONB (vs CH's parallel-array Tags.Name / Tags.Value Nested
+-- columns). Same trade-off pattern as logs/traces.
+
+CREATE TABLE IF NOT EXISTS analytics.metrics (
+    timestamp           TIMESTAMPTZ NOT NULL,
+    project_id          INTEGER NOT NULL,
+    metric_name         TEXT NOT NULL,
+    metric_value        DOUBLE PRECISION NOT NULL,
+    category            TEXT NOT NULL DEFAULT '',
+    tags                JSONB NOT NULL DEFAULT '{}'::jsonb,
+    secure_session_id   TEXT NOT NULL DEFAULT ''
+);
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+        PERFORM create_hypertable(
+            'analytics.metrics',
+            'timestamp',
+            chunk_time_interval => INTERVAL '1 day',
+            if_not_exists => TRUE
+        );
+        PERFORM add_retention_policy(
+            'analytics.metrics',
+            INTERVAL '30 days',
+            if_not_exists => TRUE
+        );
+        RAISE NOTICE 'HOL-33: metrics hypertable + 30-day retention configured';
+    END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_metrics_project_name_timestamp
+    ON analytics.metrics (project_id, metric_name, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_metrics_tags_gin
+    ON analytics.metrics USING GIN (tags);
+
+COMMENT ON TABLE analytics.metrics IS
+    'Application metrics (counters, gauges, histograms) ingested via the '
+    'OTLP receiver and HoldFast.Worker.MetricsWorker. Hypertable, 30-day '
+    'retention. HOL-33 / EPIC HOL-28.';

--- a/src/dotnet/src/HoldFast.Data.Postgres/PostgresAlertStateStore.cs
+++ b/src/dotnet/src/HoldFast.Data.Postgres/PostgresAlertStateStore.cs
@@ -1,0 +1,55 @@
+using HoldFast.Analytics;
+using HoldFast.Analytics.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoldFast.Data.Postgres;
+
+/// <summary>
+/// Postgres implementation of <see cref="IAlertStateStore"/>.
+///
+/// HOL-33. The CH impl currently stubs all four methods (returns empty lists
+/// / Task.CompletedTask) — the alert state machine isn't fully ported to .NET
+/// yet (it lived in Go's worker code). PG matches that to keep behavior
+/// identical across backends. When the .NET alert evaluator is built, both
+/// PostgresAlertStateStore and ClickHouseService get real implementations
+/// against analytics.alert_state_changes (CH already has that table from
+/// migration 000105; PG can adopt the same schema).
+/// </summary>
+public sealed class PostgresAlertStateStore : IAlertStateStore
+{
+    private readonly PostgresAnalyticsOptions _options;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<PostgresAlertStateStore> _logger;
+
+    public PostgresAlertStateStore(
+        IOptions<PostgresAnalyticsOptions> options,
+        IConfiguration configuration,
+        ILogger<PostgresAlertStateStore> logger)
+    {
+        _options = options.Value;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public Task<List<AlertStateChangeRow>> GetLastAlertStateChangesAsync(
+        int projectId, int alertId, DateTime startDate, DateTime endDate,
+        CancellationToken ct = default)
+        => Task.FromResult(new List<AlertStateChangeRow>());
+
+    public Task<List<AlertStateChangeRow>> GetAlertingAlertStateChangesAsync(
+        int projectId, int alertId, DateTime startDate, DateTime endDate,
+        CancellationToken ct = default)
+        => Task.FromResult(new List<AlertStateChangeRow>());
+
+    public Task<List<AlertStateChangeRow>> GetLastAlertingStatesAsync(
+        int projectId, int alertId, DateTime startDate, DateTime endDate,
+        CancellationToken ct = default)
+        => Task.FromResult(new List<AlertStateChangeRow>());
+
+    public Task WriteAlertStateChangesAsync(
+        int projectId, IEnumerable<AlertStateChangeRow> rows,
+        CancellationToken ct = default)
+        => Task.CompletedTask;
+}

--- a/src/dotnet/src/HoldFast.Data.Postgres/PostgresEventFieldStore.cs
+++ b/src/dotnet/src/HoldFast.Data.Postgres/PostgresEventFieldStore.cs
@@ -1,0 +1,60 @@
+using HoldFast.Analytics;
+using HoldFast.Analytics.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HoldFast.Data.Postgres;
+
+/// <summary>
+/// Postgres implementation of <see cref="IEventFieldStore"/>.
+///
+/// HOL-33. The CH impl queries a `fields` table populated by Go-side worker
+/// code that's been removed in the .NET migration (same gap as documented
+/// in PostgresSessionAnalyticsStore). Until the .NET worker rewires field
+/// population, GetEventsKeys returns the hardcoded reserved list (matches
+/// CH) and GetEventsKeyValues returns empty. Operators get an empty
+/// autocomplete rather than missing values mixed with present ones.
+/// </summary>
+public sealed class PostgresEventFieldStore : IEventFieldStore
+{
+    private readonly PostgresAnalyticsOptions _options;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<PostgresEventFieldStore> _logger;
+
+    private static readonly string[] ReservedKeys =
+        { "event", "timestamp", "session_id" };
+
+    public PostgresEventFieldStore(
+        IOptions<PostgresAnalyticsOptions> options,
+        IConfiguration configuration,
+        ILogger<PostgresEventFieldStore> logger)
+    {
+        _options = options.Value;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public Task<List<QueryKey>> GetEventsKeysAsync(
+        int projectId, DateTime startDate, DateTime endDate,
+        string? query, string? eventName, CancellationToken ct = default)
+    {
+        var keys = ReservedKeys
+            .Where(k => string.IsNullOrEmpty(query)
+                     || k.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .Select(k => new QueryKey { Name = k, Type = "String" })
+            .ToList();
+        return Task.FromResult(keys);
+    }
+
+    public Task<List<string>> GetEventsKeyValuesAsync(
+        int projectId, string keyName, DateTime startDate, DateTime endDate,
+        string? query, int? count, string? eventName, CancellationToken ct = default)
+    {
+        // Stub matching the CH gap. When the .NET worker starts populating an
+        // events catalog, this method gets the same query shape as
+        // GetSessionsKeyValues — DISTINCT value FROM analytics.event_fields
+        // WHERE key = ... AND day in range.
+        return Task.FromResult(new List<string>());
+    }
+}

--- a/src/dotnet/src/HoldFast.Data.Postgres/PostgresMetricStore.cs
+++ b/src/dotnet/src/HoldFast.Data.Postgres/PostgresMetricStore.cs
@@ -1,0 +1,218 @@
+using System.Text.Json;
+using HoldFast.Analytics;
+using HoldFast.Analytics.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace HoldFast.Data.Postgres;
+
+/// <summary>
+/// Postgres implementation of <see cref="IMetricStore"/>.
+///
+/// HOL-33. Two methods:
+/// - ReadMetricsAsync: time-bucketed aggregation with selectable aggregator
+///   (count, sum, avg, min, max, p50/p90/p95/p99, count_distinct).
+/// - WriteMetricAsync: per-row INSERT (CH's signature is per-row, not batch).
+/// </summary>
+public sealed class PostgresMetricStore : IMetricStore
+{
+    private readonly PostgresAnalyticsOptions _options;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<PostgresMetricStore> _logger;
+
+    private const int DefaultHistogramBuckets = 48;
+
+    public PostgresMetricStore(
+        IOptions<PostgresAnalyticsOptions> options,
+        IConfiguration configuration,
+        ILogger<PostgresMetricStore> logger)
+    {
+        _options = options.Value;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    private string ConnectionString =>
+        _options.ConnectionString
+        ?? _configuration.GetConnectionString("PostgreSQL")
+        ?? throw new InvalidOperationException(
+            "PostgresMetricStore: no connection string configured");
+
+    private async Task<NpgsqlConnection> OpenAsync(CancellationToken ct)
+    {
+        var conn = new NpgsqlConnection(ConnectionString);
+        await conn.OpenAsync(ct);
+        return conn;
+    }
+
+    /// <summary>
+    /// Map an aggregator name + column to a PG expression. Whitelist —
+    /// untrusted GraphQL input doesn't compose into SQL anywhere.
+    /// </summary>
+    internal static string BuildAggregatorExpression(string aggregator, string column)
+    {
+        // column is already vetted by ResolveColumn below; aggregator returns
+        // a hardcoded expression per case.
+        var col = ResolveColumn(column);
+        return (aggregator ?? "").ToUpperInvariant() switch
+        {
+            "COUNT" => "count(*)",
+            "COUNT_DISTINCT" or "COUNTDISTINCT" => $"count(DISTINCT {col})",
+            "SUM" => $"sum({col})",
+            "AVG" => $"avg({col})",
+            "MIN" => $"min({col})",
+            "MAX" => $"max({col})",
+            "P50" => $"percentile_cont(0.50) WITHIN GROUP (ORDER BY {col})",
+            "P90" => $"percentile_cont(0.90) WITHIN GROUP (ORDER BY {col})",
+            "P95" => $"percentile_cont(0.95) WITHIN GROUP (ORDER BY {col})",
+            "P99" => $"percentile_cont(0.99) WITHIN GROUP (ORDER BY {col})",
+            _ => "count(*)",
+        };
+    }
+
+    /// <summary>
+    /// Resolve a column name to a safe identifier. The metrics table only has
+    /// a small set of columns the dashboard ever aggregates over; anything
+    /// outside the whitelist falls back to metric_value (the obvious default).
+    /// </summary>
+    internal static string ResolveColumn(string? raw) =>
+        raw?.ToLowerInvariant() switch
+        {
+            "value" or "metric_value" => "metric_value",
+            "count" => "metric_value", // count(*) ignores the column anyway
+            null or "" => "metric_value",
+            _ => "metric_value", // unknown — fall back rather than allow injection
+        };
+
+    public async Task<MetricsBuckets> ReadMetricsAsync(
+        int projectId, QueryInput query, string bucketBy,
+        List<string>? groupBy, string aggregator, string? column,
+        CancellationToken ct = default)
+    {
+        var aggExpr = BuildAggregatorExpression(aggregator, column ?? "metric_value");
+        var nBuckets = DefaultHistogramBuckets;
+
+        // groupBy is operator-supplied via GraphQL — sanitize each entry to
+        // [A-Za-z0-9_] only. Anything else gets dropped.
+        var sanitizedGroupBy = (groupBy ?? new List<string>())
+            .Select(g => new string(g.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray()))
+            .Where(g => !string.IsNullOrEmpty(g))
+            .ToList();
+
+        var sql = new System.Text.StringBuilder();
+        var parameters = new Dictionary<string, object>
+        {
+            ["projectId"] = projectId,
+            ["startDate"] = query.DateRange.StartDate,
+            ["endDate"] = query.DateRange.EndDate,
+        };
+
+        if (string.Equals(bucketBy, "none", StringComparison.OrdinalIgnoreCase))
+        {
+            // No time bucketing — single result per group.
+            var groupClause = sanitizedGroupBy.Count > 0
+                ? string.Join(", ", sanitizedGroupBy.Select(g => $"tags ->> '{g}'"))
+                : null;
+
+            sql.Append($"SELECT {aggExpr} AS value, count(*)::bigint AS count");
+            if (groupClause != null)
+                sql.Append(", ").Append(groupClause).Append(" AS group_value");
+            sql.Append(" FROM analytics.metrics");
+            sql.Append(" WHERE project_id = @projectId");
+            sql.Append(" AND timestamp >= @startDate AND timestamp <= @endDate");
+            if (!string.IsNullOrWhiteSpace(query.Query))
+            {
+                sql.Append(" AND (metric_name ILIKE @q OR tags ->> 'service_name' ILIKE @q)");
+                parameters["q"] = $"%{query.Query}%";
+            }
+            if (groupClause != null)
+                sql.Append(" GROUP BY ").Append(groupClause);
+            sql.Append(" ORDER BY value DESC LIMIT 100");
+        }
+        else
+        {
+            // Time-bucketed (default).
+            sql.Append($@"
+                SELECT
+                    to_timestamp(
+                        floor(extract(epoch FROM timestamp) /
+                              GREATEST(1, (extract(epoch FROM @endDate) - extract(epoch FROM @startDate))::bigint / {nBuckets}))
+                        * GREATEST(1, (extract(epoch FROM @endDate) - extract(epoch FROM @startDate))::bigint / {nBuckets})
+                    ) AS bucket_start,
+                    {aggExpr} AS value,
+                    count(*)::bigint AS count");
+            if (sanitizedGroupBy.Count > 0)
+                sql.Append(", ").Append(string.Join(", ", sanitizedGroupBy.Select(g => $"tags ->> '{g}'"))).Append(" AS group_value");
+            sql.Append(" FROM analytics.metrics");
+            sql.Append(" WHERE project_id = @projectId");
+            sql.Append(" AND timestamp >= @startDate AND timestamp <= @endDate");
+            if (!string.IsNullOrWhiteSpace(query.Query))
+            {
+                sql.Append(" AND (metric_name ILIKE @q OR tags ->> 'service_name' ILIKE @q)");
+                parameters["q"] = $"%{query.Query}%";
+            }
+            sql.Append(" GROUP BY bucket_start");
+            if (sanitizedGroupBy.Count > 0)
+                sql.Append(", ").Append(string.Join(", ", sanitizedGroupBy.Select(g => $"tags ->> '{g}'")));
+            sql.Append(" ORDER BY bucket_start");
+        }
+
+        await using var conn = await OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(sql.ToString(), conn);
+        foreach (var (n, v) in parameters) cmd.Parameters.AddWithValue(n, v);
+
+        var buckets = new List<MetricsBucket>();
+        long total = 0;
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var bucket = new MetricsBucket();
+            int idx = 0;
+            if (!string.Equals(bucketBy, "none", StringComparison.OrdinalIgnoreCase))
+            {
+                bucket.BucketStart = reader.GetDateTime(idx++);
+                bucket.BucketEnd = bucket.BucketStart;
+            }
+            bucket.Value = reader.IsDBNull(idx) ? 0 : Convert.ToDouble(reader.GetValue(idx));
+            idx++;
+            bucket.Count = reader.IsDBNull(idx) ? 0 : reader.GetInt64(idx);
+            idx++;
+            if (sanitizedGroupBy.Count > 0 && idx < reader.FieldCount)
+            {
+                bucket.Group = reader.IsDBNull(idx) ? null : reader.GetString(idx);
+            }
+            total += bucket.Count;
+            buckets.Add(bucket);
+        }
+
+        return new MetricsBuckets { Buckets = buckets, TotalCount = total };
+    }
+
+    public async Task WriteMetricAsync(
+        int projectId, string metricName, double metricValue,
+        string? category, DateTime timestamp,
+        Dictionary<string, string>? tags, string? sessionSecureId,
+        CancellationToken ct = default)
+    {
+        const string sql = @"
+            INSERT INTO analytics.metrics (
+                timestamp, project_id, metric_name, metric_value,
+                category, tags, secure_session_id
+            ) VALUES (@ts, @projectId, @name, @value, @category, @tags, @sessionId)";
+
+        await using var conn = await OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("ts", NpgsqlDbType.TimestampTz, timestamp);
+        cmd.Parameters.AddWithValue("projectId", projectId);
+        cmd.Parameters.AddWithValue("name", metricName ?? "");
+        cmd.Parameters.AddWithValue("value", metricValue);
+        cmd.Parameters.AddWithValue("category", category ?? "");
+        cmd.Parameters.AddWithValue("tags", NpgsqlDbType.Jsonb,
+            JsonSerializer.Serialize(tags ?? new Dictionary<string, string>()));
+        cmd.Parameters.AddWithValue("sessionId", sessionSecureId ?? "");
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+}

--- a/src/dotnet/tests/HoldFast.Data.Tests/Postgres/PostgresEventAndAlertStoreTests.cs
+++ b/src/dotnet/tests/HoldFast.Data.Tests/Postgres/PostgresEventAndAlertStoreTests.cs
@@ -1,0 +1,111 @@
+using HoldFast.Analytics.Models;
+using HoldFast.Data.Postgres;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace HoldFast.Data.Tests.Postgres;
+
+/// <summary>
+/// HOL-33: tests for the two stub stores (events + alert state).
+///
+/// Both intentionally stub their methods to match the CH gap (events queries
+/// a removed Go-side `fields` table; alert state machine isn't ported to
+/// .NET yet). These tests pin the stub behavior so a future "real impl" PR
+/// has to acknowledge it's changing.
+/// </summary>
+public class PostgresEventAndAlertStoreTests
+{
+    private static readonly IConfiguration EmptyConfig =
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:PostgreSQL"] =
+                    "Host=does-not-matter-tests-do-not-connect;Database=x;Username=x;Password=x",
+            })
+            .Build();
+
+    private static readonly Microsoft.Extensions.Options.IOptions<PostgresAnalyticsOptions> Opts =
+        Options.Create(new PostgresAnalyticsOptions());
+
+    // ── EventFieldStore stubs ────────────────────────────────────────
+
+    [Fact]
+    public async Task GetEventsKeysAsync_returns_reserved_list()
+    {
+        var store = new PostgresEventFieldStore(Opts, EmptyConfig,
+            NullLogger<PostgresEventFieldStore>.Instance);
+
+        var keys = await store.GetEventsKeysAsync(1, default, default, null, null);
+        Assert.Contains(keys, k => k.Name == "event");
+        Assert.Contains(keys, k => k.Name == "timestamp");
+        Assert.Contains(keys, k => k.Name == "session_id");
+    }
+
+    [Fact]
+    public async Task GetEventsKeysAsync_filters_by_query_substring()
+    {
+        var store = new PostgresEventFieldStore(Opts, EmptyConfig,
+            NullLogger<PostgresEventFieldStore>.Instance);
+
+        var keys = await store.GetEventsKeysAsync(1, default, default, "session", null);
+        Assert.All(keys, k => Assert.Contains("session", k.Name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task GetEventsKeyValuesAsync_returns_empty_stub()
+    {
+        // Locked behavior: stub returns empty list. When the .NET worker starts
+        // populating an events catalog, this test gets updated.
+        var store = new PostgresEventFieldStore(Opts, EmptyConfig,
+            NullLogger<PostgresEventFieldStore>.Instance);
+
+        var values = await store.GetEventsKeyValuesAsync(1, "any_key", default, default, null, null, null);
+        Assert.Empty(values);
+    }
+
+    // ── AlertStateStore stubs ────────────────────────────────────────
+
+    [Fact]
+    public async Task GetLastAlertStateChangesAsync_returns_empty_stub()
+    {
+        var store = new PostgresAlertStateStore(Opts, EmptyConfig,
+            NullLogger<PostgresAlertStateStore>.Instance);
+
+        var rows = await store.GetLastAlertStateChangesAsync(1, 1, default, default);
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public async Task GetAlertingAlertStateChangesAsync_returns_empty_stub()
+    {
+        var store = new PostgresAlertStateStore(Opts, EmptyConfig,
+            NullLogger<PostgresAlertStateStore>.Instance);
+
+        var rows = await store.GetAlertingAlertStateChangesAsync(1, 1, default, default);
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public async Task GetLastAlertingStatesAsync_returns_empty_stub()
+    {
+        var store = new PostgresAlertStateStore(Opts, EmptyConfig,
+            NullLogger<PostgresAlertStateStore>.Instance);
+
+        var rows = await store.GetLastAlertingStatesAsync(1, 1, default, default);
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public async Task WriteAlertStateChangesAsync_completes_without_throwing()
+    {
+        // Stub is a no-op — any input (including null/empty/unrelated) shouldn't throw.
+        var store = new PostgresAlertStateStore(Opts, EmptyConfig,
+            NullLogger<PostgresAlertStateStore>.Instance);
+
+        await store.WriteAlertStateChangesAsync(1, []);
+        await store.WriteAlertStateChangesAsync(1,
+            [new AlertStateChangeRow { ProjectId = 1, AlertId = 1, State = "Firing" }]);
+        // No assertion needed — reaching here means the stub didn't throw.
+    }
+}

--- a/src/dotnet/tests/HoldFast.Data.Tests/Postgres/PostgresMetricStoreTests.cs
+++ b/src/dotnet/tests/HoldFast.Data.Tests/Postgres/PostgresMetricStoreTests.cs
@@ -1,0 +1,180 @@
+using HoldFast.Analytics.Models;
+using HoldFast.Data.Postgres;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Npgsql;
+
+namespace HoldFast.Data.Tests.Postgres;
+
+/// <summary>
+/// HOL-33: unit tests for PostgresMetricStore aggregator + column whitelist.
+/// </summary>
+public class PostgresMetricStoreTests
+{
+    [Theory]
+    [InlineData("COUNT", "count(*)")]
+    [InlineData("count", "count(*)")]
+    [InlineData("COUNT_DISTINCT", "count(DISTINCT metric_value)")]
+    [InlineData("countdistinct", "count(DISTINCT metric_value)")]
+    [InlineData("SUM", "sum(metric_value)")]
+    [InlineData("AVG", "avg(metric_value)")]
+    [InlineData("MIN", "min(metric_value)")]
+    [InlineData("MAX", "max(metric_value)")]
+    [InlineData("P50", "percentile_cont(0.50) WITHIN GROUP (ORDER BY metric_value)")]
+    [InlineData("P90", "percentile_cont(0.90) WITHIN GROUP (ORDER BY metric_value)")]
+    [InlineData("P95", "percentile_cont(0.95) WITHIN GROUP (ORDER BY metric_value)")]
+    [InlineData("P99", "percentile_cont(0.99) WITHIN GROUP (ORDER BY metric_value)")]
+    public void BuildAggregatorExpression_translates_known_aggregators(string aggregator, string expected)
+    {
+        Assert.Equal(expected, PostgresMetricStore.BuildAggregatorExpression(aggregator, "metric_value"));
+    }
+
+    [Theory]
+    [InlineData("UNKNOWN")]
+    [InlineData("DROP TABLE")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void BuildAggregatorExpression_falls_back_to_count_for_unknown(string? aggregator)
+    {
+        Assert.Equal("count(*)", PostgresMetricStore.BuildAggregatorExpression(aggregator!, "metric_value"));
+    }
+
+    [Theory]
+    [InlineData("metric_value", "metric_value")]
+    [InlineData("value", "metric_value")]
+    [InlineData("count", "metric_value")]
+    [InlineData(null, "metric_value")]
+    [InlineData("", "metric_value")]
+    [InlineData("user_password", "metric_value")] // unknown -> safe default
+    [InlineData("'; DROP TABLE x", "metric_value")] // SQLi attempt -> safe default
+    public void ResolveColumn_whitelists_known_columns(string? input, string expected)
+    {
+        Assert.Equal(expected, PostgresMetricStore.ResolveColumn(input));
+    }
+}
+
+/// <summary>
+/// HOL-33: live PG integration tests for metric write/read.
+/// </summary>
+[Trait("Category", "PgIntegration")]
+public class PostgresMetricStoreIntegrationTests : IAsyncLifetime
+{
+    private const string ConnectionString =
+        "Host=localhost;Port=5432;Database=postgres;Username=postgres;Password=postgres";
+
+    private PostgresMetricStore _store = null!;
+    private bool _pgReachable;
+
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            await using var probe = new NpgsqlConnection(ConnectionString);
+            await probe.OpenAsync();
+            await using var cmd = probe.CreateCommand();
+            cmd.CommandText = "SELECT to_regclass('analytics.metrics') IS NOT NULL";
+            _pgReachable = (bool)(await cmd.ExecuteScalarAsync())!;
+        }
+        catch { _pgReachable = false; }
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:PostgreSQL"] = ConnectionString,
+            })
+            .Build();
+        _store = new PostgresMetricStore(
+            Options.Create(new PostgresAnalyticsOptions { Schema = "analytics" }),
+            config,
+            NullLogger<PostgresMetricStore>.Instance);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static int NextProjectId() => 999_998_000 + (int)(DateTime.UtcNow.Ticks % 1_000);
+
+    private static async Task CleanupAsync(int projectId)
+    {
+        await using var conn = new NpgsqlConnection(ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "DELETE FROM analytics.metrics WHERE project_id = @p", conn);
+        cmd.Parameters.AddWithValue("p", projectId);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [SkippableFact]
+    public async Task WriteMetric_then_ReadMetrics_aggregates_with_sum()
+    {
+        Skip.IfNot(_pgReachable, "Postgres + analytics schema not reachable");
+        var pid = NextProjectId();
+        try
+        {
+            var ts = DateTime.UtcNow;
+            // 3 metric points: 10, 20, 30 — sum should be 60, count 3, avg 20
+            await _store.WriteMetricAsync(pid, "request_count", 10, "throughput", ts, null, null);
+            await _store.WriteMetricAsync(pid, "request_count", 20, "throughput", ts, null, null);
+            await _store.WriteMetricAsync(pid, "request_count", 30, "throughput", ts, null, null);
+
+            var queryInput = new QueryInput
+            {
+                DateRange = new DateRangeRequiredInput
+                {
+                    StartDate = ts.AddMinutes(-1),
+                    EndDate = ts.AddMinutes(1),
+                },
+            };
+
+            var sumResult = await _store.ReadMetricsAsync(pid, queryInput, "none", null, "SUM", "metric_value");
+            Assert.Single(sumResult.Buckets);
+            Assert.Equal(60.0, sumResult.Buckets[0].Value);
+            Assert.Equal(3, sumResult.Buckets[0].Count);
+
+            var avgResult = await _store.ReadMetricsAsync(pid, queryInput, "none", null, "AVG", "metric_value");
+            Assert.Equal(20.0, avgResult.Buckets[0].Value);
+
+            var p50Result = await _store.ReadMetricsAsync(pid, queryInput, "none", null, "P50", "metric_value");
+            Assert.Equal(20.0, p50Result.Buckets[0].Value);
+        }
+        finally
+        {
+            await CleanupAsync(pid);
+        }
+    }
+
+    [SkippableFact]
+    public async Task WriteMetric_with_tags_persists_them_as_jsonb()
+    {
+        Skip.IfNot(_pgReachable, "Postgres + analytics schema not reachable");
+        var pid = NextProjectId();
+        try
+        {
+            await _store.WriteMetricAsync(
+                pid, "latency", 123.4, "http",
+                DateTime.UtcNow,
+                tags: new Dictionary<string, string>
+                {
+                    ["service.name"] = "frontend",
+                    ["http.method"] = "GET",
+                },
+                sessionSecureId: "abc-secure");
+
+            await using var conn = new NpgsqlConnection(ConnectionString);
+            await conn.OpenAsync();
+            await using var cmd = new NpgsqlCommand(@"
+                SELECT tags ->> 'service.name', tags ->> 'http.method', secure_session_id
+                FROM analytics.metrics WHERE project_id = @p", conn);
+            cmd.Parameters.AddWithValue("p", pid);
+            await using var reader = await cmd.ExecuteReaderAsync();
+            await reader.ReadAsync();
+            Assert.Equal("frontend", reader.GetString(0));
+            Assert.Equal("GET", reader.GetString(1));
+            Assert.Equal("abc-secure", reader.GetString(2));
+        }
+        finally
+        {
+            await CleanupAsync(pid);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The three small remaining stores in the analytics EPIC, grouped because each is <5 methods and they share schema concerns.

- **`IMetricStore`** — real impl. 2 methods: `ReadMetricsAsync` (full `bucketBy`/`aggregator`/`groupBy` surface) + `WriteMetricAsync` (per-row insert).
- **`IEventFieldStore`** — stub matching CH gap. Hardcoded reserved-keys list; `GetEventsKeyValuesAsync` returns `[]`. CH queried a `fields` table populated by Go-side worker code that's been removed.
- **`IAlertStateStore`** — stub matching CH stub. All 4 methods return empty list / `Task.CompletedTask`. CH is also stubbed because the alert state machine isn't ported to .NET yet.

## What this PR adds

- **`analytics.metrics`** hypertable (migration 0050) — timestamp + metric_name + metric_value + JSONB tags + GIN index. Daily chunks, 30-day retention.
- **`PostgresMetricStore.cs`**:
  - `BuildAggregatorExpression`: maps `{COUNT, COUNT_DISTINCT, SUM, AVG, MIN, MAX, P50, P90, P95, P99}` to PG expressions. Percentiles via `percentile_cont WITHIN GROUP`. Unknown aggregators fall back to `count(*)`.
  - `ResolveColumn`: whitelists column to `metric_value`; SQLi/unknown inputs fall back.
  - `ReadMetricsAsync`: supports `"none"` (no time bucketing) and time-bucketed paths. `groupBy` items sanitized to `[A-Za-z0-9_]` and looked up via `tags ->> 'key'`.
- **`PostgresEventFieldStore.cs`** + **`PostgresAlertStateStore.cs`** — stubbed for parity. Gaps documented in code.
- **Per-domain DI swaps**: `Storage:Analytics:MetricStore / EventFieldStore / AlertStateStore = postgres`.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — **3,173 pass** (was 3,141; +32)
  - 16 unit tests for aggregator + column whitelists (SQLi-attempt aggregators, unknown columns)
  - 2 integration tests against live PG: SUM/AVG/P50 aggregate roundtrip, JSONB tags + secure_session_id persistence
  - 8 stub-behavior tests pinning empty-list / no-throw semantics for events + alert state (so a future "real impl" PR has to acknowledge it's changing)
- [x] Five hypertables now: `logs`, `traces`, `sessions`, `error_objects`, `metrics`

**With HOL-33 merged, all six per-domain stores are implemented.** Only HOL-34 remains in the EPIC: consolidate the per-domain `Storage:Analytics:*Store` switches into a single `Storage:Analytics = ClickHouse | Postgres` knob, and make the CH container opt-in.

Closes [HOL-33](https://yt.brewingcoder.com/issue/HOL-33). Five-of-six stories of the Postgres-backend EPIC ([HOL-28](https://yt.brewingcoder.com/issue/HOL-28)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)