### PR TITLE
infra+dotnet: Storage:Analytics single-knob switch + CH opt-in profile (HOL-34)

### DIFF
--- a/infra/docker/.env.example
+++ b/infra/docker/.env.example
@@ -12,6 +12,15 @@ COMPOSE_PROJECT_NAME=holdfast
 COMPOSE_FILE=compose.yml
 COMPOSE_PATH_SEPARATOR=:
 
+# HOL-34: analytics backend choice. Default is ClickHouse (matches
+# existing deployments). Set to `postgres` to swap to TimescaleDB
+# and skip the ~600 MiB CH idle container.
+#   COMPOSE_PROFILES=clickhouse  → starts CH alongside PG (default)
+#   COMPOSE_PROFILES=postgres    → PG-only, CH container skipped
+# (also set Storage:Analytics=Postgres in the backend env to wire DI)
+COMPOSE_PROFILES=clickhouse
+STORAGE_ANALYTICS=ClickHouse
+
 # ── Container images ────────────────────────────────────────────────
 # Backend image defaults to a locally-built holdfast-backend-dotnet:latest.
 # Leave unset (or set to empty) to let compose use the in-tree build.

--- a/infra/docker/compose.hobby-dotnet.yml
+++ b/infra/docker/compose.hobby-dotnet.yml
@@ -30,6 +30,12 @@ services:
             - DevSeed__AdminEmail=${DEV_SEED_ADMIN_EMAIL:-dev@holdfast.local}
             - DevSeed__AdminName=${DEV_SEED_ADMIN_NAME:-Dev Admin}
             - OTEL_EXPORTER_OTLP_ENDPOINT=http://backend:8082
+            # HOL-34: single-knob analytics backend selection. Defaults to
+            # ClickHouse so existing deploys behave unchanged. Set
+            # STORAGE_ANALYTICS=Postgres in .env (along with
+            # COMPOSE_PROFILES=postgres) to swap the entire analytics layer
+            # to TimescaleDB and skip the CH container.
+            - Storage__Analytics=${STORAGE_ANALYTICS:-ClickHouse}
         env_file: .env
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:8082/health']

--- a/infra/docker/compose.yml
+++ b/infra/docker/compose.yml
@@ -39,7 +39,13 @@ services:
             timeout: 5s
             retries: 5
 
+    # HOL-34: CH is gated behind the `clickhouse` profile. The default
+    # COMPOSE_PROFILES=clickhouse (set in .env.example) keeps the container
+    # in the existing-behavior set. PG-only deployments override
+    # COMPOSE_PROFILES=postgres in their .env and CH is skipped, saving
+    # the ~600 MiB idle baseline.
     clickhouse:
+        profiles: ["clickhouse"]
         logging: *local-logging
         container_name: clickhouse
         image: ${CLICKHOUSE_IMAGE_NAME}

--- a/src/dotnet/src/HoldFast.Api/Program.cs
+++ b/src/dotnet/src/HoldFast.Api/Program.cs
@@ -151,21 +151,23 @@ builder.Services.AddSingleton<IKafkaProducer, KafkaProducerAdapter>();
 builder.Services.Configure<ClickHouseOptions>(
     builder.Configuration.GetSection("ClickHouse"));
 
-// HOL-25: ClickHouseService implements both the legacy IClickHouseService
-// and the seven backend-neutral domain stores. Register the singleton once
-// and resolve all eight interfaces through it — different callers can hold
-// any subset and DI hands back the same instance.
+// HOL-25/29-33: ClickHouseService and the seven Postgres-backed
+// PostgresXxxStore classes both exist as DI singletons. The seven analytics
+// interfaces (ILogStore, ITraceStore, ISessionAnalyticsStore,
+// IErrorAnalyticsStore, IMetricStore, IEventFieldStore, IAlertStateStore)
+// are bound to one or the other based on a single config knob.
 //
-// HOL-29: per-domain backend swap. Each store can be toggled independently
-// via Storage:Analytics:<StoreName> config (e.g. Storage:Analytics:LogStore =
-// postgres). Default is ClickHouse (matches existing behavior). HOL-34 will
-// consolidate this into a single Storage:Analytics top-level switch.
+// HOL-34 consolidation: previously each store had its own
+// Storage:Analytics:<StoreName> override. The single Storage:Analytics knob
+// is the supported deploy-time choice; per-domain overrides survive only as
+// optional escape hatches for testing mixed configurations.
+//
+// Default: ClickHouse (zero-config behavior matches the pre-EPIC stack).
+// Set Storage:Analytics=Postgres (or env STORAGE__ANALYTICS=Postgres) to
+// run the entire analytics layer on PG and drop the ClickHouse container.
 builder.Services.AddSingleton<ClickHouseService>();
 builder.Services.AddSingleton<IClickHouseService>(sp => sp.GetRequiredService<ClickHouseService>());
 
-// PostgresLogStore registered as concrete type so it can be DI-injected
-// either as ILogStore (when LogStore=postgres) or directly for tests/health
-// checks without forcing it onto every deployment.
 builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresLogStore>();
 builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresTraceStore>();
 builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresSessionAnalyticsStore>();
@@ -174,75 +176,49 @@ builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresMetricStore>();
 builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresEventFieldStore>();
 builder.Services.AddSingleton<HoldFast.Data.Postgres.PostgresAlertStateStore>();
 
-var logStoreBackend = builder.Configuration["Storage:Analytics:LogStore"] ?? "clickhouse";
-if (logStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
+// Resolve each interface — top-level Storage:Analytics drives all seven by
+// default; the per-domain overrides (Storage:Analytics:<StoreName>) take
+// precedence when set, so a mixed config (e.g. logs on PG, everything else
+// on CH) still works for testing.
+var defaultBackend = builder.Configuration["Storage:Analytics"] ?? "clickhouse";
+
+static bool UsePostgres(IConfiguration config, string overrideKey, string defaultBackend)
 {
-    builder.Services.AddSingleton<HoldFast.Analytics.ILogStore>(
-        sp => sp.GetRequiredService<HoldFast.Data.Postgres.PostgresLogStore>());
-}
-else
-{
-    builder.Services.AddSingleton<HoldFast.Analytics.ILogStore>(
-        sp => sp.GetRequiredService<ClickHouseService>());
+    var explicitOverride = config[$"Storage:Analytics:{overrideKey}"];
+    var effective = !string.IsNullOrEmpty(explicitOverride) ? explicitOverride : defaultBackend;
+    return effective.Equals("postgres", StringComparison.OrdinalIgnoreCase);
 }
 
-var traceStoreBackend = builder.Configuration["Storage:Analytics:TraceStore"] ?? "clickhouse";
-if (traceStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
-{
-    builder.Services.AddSingleton<HoldFast.Analytics.ITraceStore>(
-        sp => sp.GetRequiredService<HoldFast.Data.Postgres.PostgresTraceStore>());
-}
-else
-{
-    builder.Services.AddSingleton<HoldFast.Analytics.ITraceStore>(
-        sp => sp.GetRequiredService<ClickHouseService>());
-}
+builder.Services.AddSingleton<HoldFast.Analytics.ILogStore>(sp =>
+    UsePostgres(builder.Configuration, "LogStore", defaultBackend)
+        ? sp.GetRequiredService<HoldFast.Data.Postgres.PostgresLogStore>()
+        : sp.GetRequiredService<ClickHouseService>());
+builder.Services.AddSingleton<HoldFast.Analytics.ITraceStore>(sp =>
+    UsePostgres(builder.Configuration, "TraceStore", defaultBackend)
+        ? sp.GetRequiredService<HoldFast.Data.Postgres.PostgresTraceStore>()
+        : sp.GetRequiredService<ClickHouseService>());
+builder.Services.AddSingleton<HoldFast.Analytics.ISessionAnalyticsStore>(sp =>
+    UsePostgres(builder.Configuration, "SessionStore", defaultBackend)
+        ? sp.GetRequiredService<HoldFast.Data.Postgres.PostgresSessionAnalyticsStore>()
+        : sp.GetRequiredService<ClickHouseService>());
+builder.Services.AddSingleton<HoldFast.Analytics.IErrorAnalyticsStore>(sp =>
+    UsePostgres(builder.Configuration, "ErrorStore", defaultBackend)
+        ? sp.GetRequiredService<HoldFast.Data.Postgres.PostgresErrorAnalyticsStore>()
+        : sp.GetRequiredService<ClickHouseService>());
+builder.Services.AddSingleton<HoldFast.Analytics.IMetricStore>(sp =>
+    UsePostgres(builder.Configuration, "MetricStore", defaultBackend)
+        ? sp.GetRequiredService<HoldFast.Data.Postgres.PostgresMetricStore>()
+        : sp.GetRequiredService<ClickHouseService>());
+builder.Services.AddSingleton<HoldFast.Analytics.IEventFieldStore>(sp =>
+    UsePostgres(builder.Configuration, "EventFieldStore", defaultBackend)
+        ? sp.GetRequiredService<HoldFast.Data.Postgres.PostgresEventFieldStore>()
+        : sp.GetRequiredService<ClickHouseService>());
+builder.Services.AddSingleton<HoldFast.Analytics.IAlertStateStore>(sp =>
+    UsePostgres(builder.Configuration, "AlertStateStore", defaultBackend)
+        ? sp.GetRequiredService<HoldFast.Data.Postgres.PostgresAlertStateStore>()
+        : sp.GetRequiredService<ClickHouseService>());
 
-var sessionStoreBackend = builder.Configuration["Storage:Analytics:SessionStore"] ?? "clickhouse";
-if (sessionStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
-{
-    builder.Services.AddSingleton<HoldFast.Analytics.ISessionAnalyticsStore>(
-        sp => sp.GetRequiredService<HoldFast.Data.Postgres.PostgresSessionAnalyticsStore>());
-}
-else
-{
-    builder.Services.AddSingleton<HoldFast.Analytics.ISessionAnalyticsStore>(
-        sp => sp.GetRequiredService<ClickHouseService>());
-}
-var errorStoreBackend = builder.Configuration["Storage:Analytics:ErrorStore"] ?? "clickhouse";
-if (errorStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
-{
-    builder.Services.AddSingleton<HoldFast.Analytics.IErrorAnalyticsStore>(
-        sp => sp.GetRequiredService<HoldFast.Data.Postgres.PostgresErrorAnalyticsStore>());
-}
-else
-{
-    builder.Services.AddSingleton<HoldFast.Analytics.IErrorAnalyticsStore>(
-        sp => sp.GetRequiredService<ClickHouseService>());
-}
-var metricStoreBackend = builder.Configuration["Storage:Analytics:MetricStore"] ?? "clickhouse";
-if (metricStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
-    builder.Services.AddSingleton<HoldFast.Analytics.IMetricStore>(
-        sp => sp.GetRequiredService<HoldFast.Data.Postgres.PostgresMetricStore>());
-else
-    builder.Services.AddSingleton<HoldFast.Analytics.IMetricStore>(
-        sp => sp.GetRequiredService<ClickHouseService>());
-
-var eventFieldStoreBackend = builder.Configuration["Storage:Analytics:EventFieldStore"] ?? "clickhouse";
-if (eventFieldStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
-    builder.Services.AddSingleton<HoldFast.Analytics.IEventFieldStore>(
-        sp => sp.GetRequiredService<HoldFast.Data.Postgres.PostgresEventFieldStore>());
-else
-    builder.Services.AddSingleton<HoldFast.Analytics.IEventFieldStore>(
-        sp => sp.GetRequiredService<ClickHouseService>());
-
-var alertStoreBackend = builder.Configuration["Storage:Analytics:AlertStateStore"] ?? "clickhouse";
-if (alertStoreBackend.Equals("postgres", StringComparison.OrdinalIgnoreCase))
-    builder.Services.AddSingleton<HoldFast.Analytics.IAlertStateStore>(
-        sp => sp.GetRequiredService<HoldFast.Data.Postgres.PostgresAlertStateStore>());
-else
-    builder.Services.AddSingleton<HoldFast.Analytics.IAlertStateStore>(
-        sp => sp.GetRequiredService<ClickHouseService>());
+Console.WriteLine($"HoldFast analytics backend: '{defaultBackend}' (override Storage:Analytics)");
 
 // Migration runner — applies src/backend/clickhouse/migrations/*.up.sql at
 // startup, idempotently. Disable via ClickHouse__Migrations__Disabled=true


### PR DESCRIPTION
## Summary

**Final story of the Postgres analytics EPIC.** Consolidates the seven per-domain `Storage:Analytics:<StoreName>` knobs introduced across HOL-29..33 into a single `Storage:Analytics` switch, and makes the ClickHouse container opt-in via a compose profile so PG-only deployments save the ~600 MiB CH idle baseline.

## What this PR adds

### DI consolidation (`Program.cs`)
- Single `Storage:Analytics` config drives the binding for all seven analytics interfaces. Default is `ClickHouse` (zero-config matches pre-EPIC behavior).
- Per-domain overrides (`Storage:Analytics:<StoreName>`) survive as optional escape hatches — mixed configs like "logs on PG, errors on CH" still work for testing — but they're no longer the documented deploy-time switch.
- Backend logs the active backend on startup so operators can confirm wiring without grep.

### Compose profile (`infra/docker/compose.yml`)
- ClickHouse service moves under `profiles: ["clickhouse"]`. Default `COMPOSE_PROFILES=clickhouse` in `.env.example` keeps existing behavior — CH still starts.
- PG-only deploys override `COMPOSE_PROFILES=postgres`. CH is skipped.

### Backend env (`compose.hobby-dotnet.yml`)
- New `Storage__Analytics` env var, defaulted to `ClickHouse`, plumbed from host's `STORAGE_ANALYTICS` value.

### Documentation
- `.env.example` header explains the two-line switch (`COMPOSE_PROFILES` + `STORAGE_ANALYTICS`) for PG-only.

## What this PR does NOT do

- **Delete `IClickHouseService`.** The original EPIC plan called for the legacy kitchen-sink interface to be removed in HOL-34 once all 12 callers had migrated to the per-domain interfaces. That caller migration didn't happen — HOL-29..33 added the new interfaces *alongside* `IClickHouseService`. The kitchen-sink interface stays alive; deleting it requires a separate cleanup PR. **Filing as follow-up.**

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — **3,173 pass** (unchanged; this is a DI shape refactor, no new domain logic)
- [x] **Live-verified** compose service set under both profiles:
  - `COMPOSE_PROFILES=clickhouse` → `backend + postgres + clickhouse`
  - `COMPOSE_PROFILES=postgres` → `backend + postgres` only

## Stats

4 files changed, +73 / -76.

Closes [HOL-34](https://yt.brewingcoder.com/issue/HOL-34). **EPIC [HOL-28](https://yt.brewingcoder.com/issue/HOL-28) (Postgres analytics backend) is now complete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)