### PR TITLE
dotnet: HotChocolate 15.1.12 → 16.0.0 — clears critical CVE GHSA-qr3m-xw4c-jqw3 (HOL-16)

### DIFF
--- a/src/dotnet/src/HoldFast.Api/HoldFast.Api.csproj
+++ b/src/dotnet/src/HoldFast.Api/HoldFast.Api.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
-    <PackageReference Include="HotChocolate.AspNetCore" Version="15.1.12" />
-    <PackageReference Include="HotChocolate.Data.EntityFramework" Version="15.1.12" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="16.0.0" />
+    <PackageReference Include="HotChocolate.Data.EntityFramework" Version="16.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.29.3" />
     <PackageReference Include="IronSnappy" Version="1.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />

--- a/src/dotnet/src/HoldFast.Api/UserRequestInterceptor.cs
+++ b/src/dotnet/src/HoldFast.Api/UserRequestInterceptor.cs
@@ -32,9 +32,12 @@ public sealed class UserRequestInterceptor : DefaultHttpRequestInterceptor
             "UserRequestInterceptor: path={Path} isAuthenticated={IsAuth} uid={Uid}",
             context.Request.Path, isAuth, uid ?? "(null)");
 
-        // Forward the authenticated user into HC's global state under the well-known key.
-        // HC's resolver compiler binds ClaimsPrincipal parameters from WellKnownContextData.UserState.
-        requestBuilder.SetGlobalState(WellKnownContextData.UserState, context.User);
+        // Forward the authenticated user into the GraphQL operation request.
+        // HOL-16: HC 16 introduced OperationRequestBuilder.SetUser(...) which
+        // replaces the old WellKnownContextData.UserState global-state pattern.
+        // HC's resolver compiler binds ClaimsPrincipal parameters from this slot.
+        if (context.User is not null)
+            requestBuilder.SetUser(context.User);
 
         return base.OnCreateAsync(context, requestExecutor, requestBuilder, cancellationToken);
     }

--- a/src/dotnet/src/HoldFast.GraphQL.Private/HoldFast.GraphQL.Private.csproj
+++ b/src/dotnet/src/HoldFast.GraphQL.Private/HoldFast.GraphQL.Private.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="15.1.12" />
-    <PackageReference Include="HotChocolate.Data" Version="15.1.12" />
-    <PackageReference Include="HotChocolate.Data.EntityFramework" Version="15.1.12" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="16.0.0" />
+    <PackageReference Include="HotChocolate.Data" Version="16.0.0" />
+    <PackageReference Include="HotChocolate.Data.EntityFramework" Version="16.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/dotnet/src/HoldFast.GraphQL.Private/IdFieldTypeInterceptor.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Private/IdFieldTypeInterceptor.cs
@@ -1,6 +1,6 @@
 using HotChocolate.Configuration;
 using HotChocolate.Types;
-using HotChocolate.Types.Descriptors.Definitions;
+using HotChocolate.Types.Descriptors.Configurations;
 
 namespace HoldFast.GraphQL.Private;
 
@@ -14,14 +14,19 @@ namespace HoldFast.GraphQL.Private;
 ///
 /// This interceptor ensures that any field named exactly "id" on any object type
 /// is typed as `ID!`, matching the Go schema convention.
+///
+/// HOL-16: HotChocolate 16 renamed the descriptor namespace
+/// (HotChocolate.Types.Descriptors.Definitions → .Configurations) and the
+/// base type (DefinitionBase → TypeSystemConfiguration). The hook signature
+/// is otherwise unchanged.
 /// </summary>
 public class IdFieldTypeInterceptor : TypeInterceptor
 {
     public override void OnBeforeCompleteType(
         ITypeCompletionContext completionContext,
-        DefinitionBase definition)
+        TypeSystemConfiguration configuration)
     {
-        if (definition is not ObjectTypeDefinition typeDef)
+        if (configuration is not ObjectTypeConfiguration typeDef)
             return;
 
         foreach (var field in typeDef.Fields)

--- a/src/dotnet/src/HoldFast.GraphQL.Private/TimestampType.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Private/TimestampType.cs
@@ -1,86 +1,98 @@
 using System.Globalization;
+using System.Text.Json;
+using HotChocolate.Features;
 using HotChocolate.Language;
+using HotChocolate.Text.Json;
 using HotChocolate.Types;
 
 namespace HoldFast.GraphQL.Private;
 
 /// <summary>
 /// Custom scalar that maps C# DateTime to the Go schema's Timestamp scalar.
-/// The Go/gqlgen backend exposes all date/time fields as the Timestamp scalar (an ISO 8601 string).
-/// HC's built-in DateTime scalar uses the name "DateTime", causing schema mismatches when the
-/// frontend sends variables typed as Timestamp.
+/// The Go/gqlgen backend exposes all date/time fields as the Timestamp scalar
+/// (an ISO 8601 string). HC's built-in DateTime scalar uses the name "DateTime",
+/// causing schema mismatches when the frontend sends variables typed as Timestamp.
 ///
-/// HC variable coercion flow for input scalars:
-///   JSON string → ParseResult(string) → StringValueNode → ParseLiteral(StringValueNode) → DateTime
+/// HOL-16: rewritten for HotChocolate 16's ScalarType API. The four override
+/// points changed:
 ///
-/// Accepts common ISO 8601 formats including milliseconds ("2024-01-15T10:00:00.000Z").
-/// Serializes as ISO 8601 UTC string ("2024-01-15T10:00:00.0000000Z").
+///   HC 15                                    HC 16
+///   ──────────────────────────────────────   ──────────────────────────────────
+///   ParseLiteral(StringValueNode)            OnCoerceInputLiteral(StringValueNode)
+///   ParseValue(DateTime)                     OnValueToLiteral(DateTime)
+///   ParseResult(object?)                     (removed; folded into OnCoerceOutputValue)
+///   Serialize(object?)                       OnCoerceOutputValue(DateTime, ResultElement)
+///   TryDeserialize(object?, out object?)     OnCoerceInputValue(JsonElement, IFeatureProvider)
+///
+/// Accepts common ISO 8601 formats including milliseconds; serializes as ISO 8601 UTC.
 /// </summary>
 public sealed class TimestampType : ScalarType<DateTime, StringValueNode>
 {
     public TimestampType() : base("Timestamp") { }
 
-    protected override DateTime ParseLiteral(StringValueNode valueSyntax)
+    /// <summary>
+    /// HC 16 input-coercion path: literal AST node → runtime value. Called when
+    /// the GraphQL document contains a string literal for a Timestamp arg.
+    /// </summary>
+    protected override DateTime OnCoerceInputLiteral(StringValueNode valueSyntax)
     {
-        // Use DateTimeOffset.TryParse for robust ISO 8601 parsing (handles Z, +00:00, etc.)
         if (DateTimeOffset.TryParse(
-            valueSyntax.Value,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal,
-            out var dto))
+                valueSyntax.Value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal,
+                out var dto))
+        {
             return dto.UtcDateTime;
-        throw new SerializationException(
-            $"Cannot parse '{valueSyntax.Value}' as Timestamp.", this);
+        }
+        throw new LeafCoercionException(
+            $"Cannot parse '{valueSyntax.Value}' as Timestamp.", this, HotChocolate.Path.Root);
     }
-
-    protected override StringValueNode ParseValue(DateTime runtimeValue)
-        => new(runtimeValue.ToUniversalTime().ToString("o"));
 
     /// <summary>
-    /// Called by HC when coercing result values (e.g., from JSON variable strings).
-    /// Wraps the raw value as a StringValueNode so ParseLiteral can handle it.
+    /// HC 16 input-coercion path: JSON variable → runtime value. Called when
+    /// the variable is supplied via the variables map (most common case from
+    /// the dashboard frontend, which sends timestamps as JSON strings).
     /// </summary>
-    public override IValueNode ParseResult(object? resultValue)
+    protected override DateTime OnCoerceInputValue(JsonElement value, IFeatureProvider features)
     {
-        if (resultValue is DateTime dt)
-            return new StringValueNode(dt.ToUniversalTime().ToString("o"));
-        if (resultValue is DateTimeOffset dto)
-            return new StringValueNode(dto.UtcDateTime.ToString("o"));
-        if (resultValue is string s)
-            return new StringValueNode(s);
-        if (resultValue is null)
-            return NullValueNode.Default;
-        throw new SerializationException(
-            $"Cannot serialize {resultValue.GetType().Name} as Timestamp.", this);
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            var s = value.GetString();
+            if (s is null)
+                throw new LeafCoercionException("Timestamp string is null.", this, HotChocolate.Path.Root);
+            if (DateTimeOffset.TryParse(
+                    s,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal,
+                    out var dto))
+            {
+                return dto.UtcDateTime;
+            }
+            throw new LeafCoercionException(
+                $"Cannot parse '{s}' as Timestamp.", this, HotChocolate.Path.Root);
+        }
+        throw new LeafCoercionException(
+            $"Cannot coerce {value.ValueKind} to Timestamp; expected string.", this, HotChocolate.Path.Root);
     }
 
-    public override object? Serialize(object? runtimeValue)
-        => runtimeValue is DateTime dt
-            ? dt.ToUniversalTime().ToString("o")
-            : null;
+    /// <summary>
+    /// HC 16 literal-build path: runtime value → literal AST. Used when HC
+    /// needs to inline a Timestamp into a printed query (e.g., introspection
+    /// default values).
+    /// </summary>
+    protected override StringValueNode OnValueToLiteral(DateTime runtimeValue)
+        => new(runtimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture));
 
-    public override bool TryDeserialize(object? resultValue, out object? runtimeValue)
-    {
-        if (resultValue is DateTime d)
-        {
-            runtimeValue = d;
-            return true;
-        }
-        if (resultValue is DateTimeOffset dto)
-        {
-            runtimeValue = dto.UtcDateTime;
-            return true;
-        }
-        if (resultValue is string s && DateTimeOffset.TryParse(
-            s,
-            CultureInfo.InvariantCulture,
-            DateTimeStyles.AssumeUniversal,
-            out var parsed))
-        {
-            runtimeValue = parsed.UtcDateTime;
-            return true;
-        }
-        runtimeValue = null;
-        return false;
-    }
+    /// <summary>
+    /// HC 16 output-coercion path: runtime value is written into the result
+    /// element directly. Replaces the old Serialize/ParseResult split — HC 16
+    /// inverted the contract from "return a value" to "write a value into the
+    /// destination" so the executor can avoid intermediate boxing.
+    ///
+    /// SetStringValue produces the same JSON output as the old
+    /// `Serialize(...) → string` path: a quoted ISO 8601 string matching the
+    /// Go schema's Timestamp wire format.
+    /// </summary>
+    protected override void OnCoerceOutputValue(DateTime runtimeValue, ResultElement element)
+        => element.SetStringValue(runtimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture));
 }

--- a/src/dotnet/src/HoldFast.GraphQL.Public/HoldFast.GraphQL.Public.csproj
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/HoldFast.GraphQL.Public.csproj
@@ -7,7 +7,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="15.1.12" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="16.0.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary

Bumps all HotChocolate packages 15.1.12 → 16.0.0 to clear the critical parser CVE that's been warning on every build. Three source files updated to HC 16's reshaped APIs. **Zero test regressions; CVE confirmed cleared.**

## What this PR changes

### Packages (6 references across 3 csproj files)
- `HotChocolate.AspNetCore` 15.1.12 → 16.0.0
- `HotChocolate.Data` 15.1.12 → 16.0.0
- `HotChocolate.Data.EntityFramework` 15.1.12 → 16.0.0

### Source code
- **`IdFieldTypeInterceptor.cs`**: HC 16 renamed the descriptor namespace (`HotChocolate.Types.Descriptors.Definitions` → `.Configurations`) and reshaped the base type (`DefinitionBase` → `TypeSystemConfiguration`, `ObjectTypeDefinition` → `ObjectTypeConfiguration`). Hook signature is otherwise unchanged.
- **`TimestampType.cs`**: HC 16's `ScalarType<,>` abstract methods all renamed + reshaped:
  | HC 15 | HC 16 |
  |---|---|
  | `ParseLiteral` | `OnCoerceInputLiteral` |
  | `ParseValue` | `OnValueToLiteral` |
  | `ParseResult` | (removed; folded into output coercion) |
  | `Serialize` | `OnCoerceOutputValue` — now writes into a `ResultElement` instead of returning a value (inverted contract for zero-alloc) |
  | `TryDeserialize` | `OnCoerceInputValue(JsonElement, IFeatureProvider)` — input is now `JsonElement` not `object` |

  Plus `SerializationException` is gone — replaced by `HotChocolate.Types.LeafCoercionException(message, type, path)`.
- **`UserRequestInterceptor.cs`**: the `WellKnownContextData.UserState` + `SetGlobalState()` pattern is replaced by HC 16's cleaner `OperationRequestBuilder.SetUser(ClaimsPrincipal)` extension.

## Test plan

- [x] `dotnet build` — 0 errors, 0 new warnings
- [x] `dotnet test` — **3,171 pass** (no change; all 1,151 GraphQL tests still green — the highest-risk surface for this kind of migration)
- [x] `dotnet list package --vulnerable --include-transitive` — **zero vulnerable packages** across all 18 projects
- [ ] BrowserSdkIngestTests + NodeSdkIngestTests against a rebuilt backend image — recommend reviewer rebuild + smoke before merge

## Background

The original HOL-16 plan targeted 15.2.x. A prior attempt at the cheaper "pin `HotChocolate.Language=16.0.0` alone" path *built* but crashed at runtime with `Method not found: ParserOptions..ctor` because 15.x and 16.x assemblies aren't ABI-compatible. Full HC 16 migration was the only viable path; the migration plan was documented in detail on the HOL-16 ticket; this PR executes it.

## Stats

6 files changed, +91 / -71. Surprisingly tight diff for clearing a critical CVE in a dependency that pervades the GraphQL layer.

Closes [HOL-16](https://yt.brewingcoder.com/issue/HOL-16). The persistent NU1904 warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)