### PR TITLE
tests: soak harness scaffolding + entrypoint (HOL-38, EPIC HOL-37)

### DIFF
--- a/infra/docker/compose.soak.yml
+++ b/infra/docker/compose.soak.yml
@@ -1,0 +1,38 @@
+# HOL-38: soak-harness compose overlay.
+#
+# Layer this on top of the hobby/dotnet stack to run the analytics-ingest
+# soak generator alongside the existing services:
+#
+#   docker compose -f compose.yml -f compose.hobby-dotnet.yml -f compose.soak.yml up -d
+#
+# By default the harness emits one event per minute; HOL-40 turns that into
+# a variable-rate timer with periodic spike windows. Start/stop is via the
+# `soak` profile so existing `up` invocations don't accidentally pull it in:
+#
+#   docker compose --profile soak ... up -d        # include soak
+#   docker compose ... up -d                       # skip soak (default)
+
+services:
+    soak:
+        profiles: ["soak"]
+        container_name: holdfast-soak
+        build:
+            context: ../../tests/soak
+            dockerfile: Dockerfile
+        image: holdfast-soak:latest
+        restart: on-failure
+        depends_on:
+            backend:
+                condition: service_healthy
+        environment:
+            # Hobby DevSeed assigns ID 2 to the "HoldFast Dev / default" project.
+            # Override SOAK_PROJECT_ID for non-DevSeed deployments.
+            - HOLDFAST_PROJECT_ID=${SOAK_PROJECT_ID:-2}
+            # Backend's in-cluster name on the compose network.
+            - OTLP_ENDPOINT=http://backend:8082/otel
+            # Default 60 s base interval — HOL-40 will document the spike-mode
+            # env vars that build on this.
+            - SOAK_BASE_INTERVAL_MS=${SOAK_BASE_INTERVAL_MS:-60000}
+            - SOAK_SERVICE_NAME=${SOAK_SERVICE_NAME:-holdfast-soak}
+            - SOAK_SERVICE_VERSION=${SOAK_SERVICE_VERSION:-0.0.0-soak}
+        # No port mappings; soak is outbound-only.

--- a/tests/soak/.gitignore
+++ b/tests/soak/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/tests/soak/Dockerfile
+++ b/tests/soak/Dockerfile
@@ -1,0 +1,30 @@
+# HOL-38: soak harness container.
+#
+# Single-stage Alpine + Node — the entire harness is JS/Node, no compile step.
+# Layered so npm install caches when only index.mjs / scenarios change.
+
+FROM node:lts-alpine
+
+WORKDIR /app
+
+# Install deps in a separate layer for cache reuse
+COPY package.json ./
+RUN npm install --omit=dev
+
+# Source last so changes don't bust the deps layer
+COPY index.mjs ./
+COPY scenarios ./scenarios/
+# scheduler.mjs lands in HOL-40; ignore-if-missing via a glob trick
+COPY scheduler*.mjs ./
+
+# Defaults; override via compose env
+ENV SOAK_BASE_INTERVAL_MS=60000 \
+    HOLDFAST_PROJECT_ID=2 \
+    OTLP_ENDPOINT=http://backend:8082/otel \
+    SOAK_SERVICE_NAME=holdfast-soak \
+    SOAK_SERVICE_VERSION=0.0.0-soak
+
+# No EXPOSE — soak only makes outbound calls.
+# No HEALTHCHECK — `docker logs holdfast-soak` is the operator-facing signal.
+
+ENTRYPOINT ["node", "index.mjs"]

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -1,0 +1,87 @@
+# HoldFast soak harness
+
+Long-running container that exercises the analytics-ingest surface
+(logs / traces / errors / sessions / metrics / events) with variable-rate
+randomized scenarios. Designed to run for ~24 hours alongside the hobby
+stack so we can observe real-world ingest pressure on the analytics backend.
+
+## Status
+
+- ✅ **HOL-38** (this ticket) — container scaffolding + entrypoint with placeholder
+  scenarios. Container boots, emits one INFO log + one trivial trace per
+  tick, exits cleanly on SIGTERM.
+- 🟡 **HOL-39** — scenario library (logs / traces / errors / sessions / metrics / events)
+- 🟡 **HOL-40** — variable-rate scheduler with spike windows
+- 🟡 **HOL-41** — operator runbook + verification queries
+
+## Quick start
+
+```bash
+cd infra/docker
+cp .env.example .env  # if you don't have one yet
+
+# Bring up the stack PLUS the soak harness
+docker compose -f compose.yml \
+               -f compose.hobby-dotnet.yml \
+               -f compose.soak.yml \
+               --profile soak \
+               up -d
+
+# Watch the harness emit ticks
+docker logs -f holdfast-soak
+
+# Stop just the soak (leaves the rest of the stack running)
+docker compose --profile soak stop soak
+```
+
+## Configuration (env)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `HOLDFAST_PROJECT_ID` | `2` | Project id under which to emit data. Default matches DevSeed's "HoldFast Dev / default" project. |
+| `OTLP_ENDPOINT` | `http://backend:8082/otel` | Where the OTel exporters POST. Compose-network hostname. |
+| `SOAK_BASE_INTERVAL_MS` | `60000` | Tick interval. Lower for faster local validation, higher for gentler 24h runs. |
+| `SOAK_SERVICE_NAME` | `holdfast-soak` | `service.name` resource attribute on every span/log — use this in queries to filter soak-generated rows from real traffic. |
+| `SOAK_SERVICE_VERSION` | `0.0.0-soak` | `service.version` resource attribute. |
+
+## Output protocol
+
+Every tick emits one line of JSON to stdout:
+
+```json
+{"ts":"2026-05-09T18:42:00.123Z","event":"soak.tick","tick":3,"elapsed_ms":7,"scenarios_emitted":["placeholder-log","placeholder-trace"]}
+```
+
+Pipe through `jq -c` for quick filtering. Special events:
+- `soak.started` — emitted once at boot with the resolved config
+- `soak.stopping` — emitted on SIGTERM/SIGINT before clean shutdown
+- `soak.shutdown.error` / `soak.crash` — exporter-flush or unhandled errors
+
+## Verifying ingest
+
+While the harness runs, the analytics store should accumulate rows tagged with `service.name=holdfast-soak`. From `psql` or `clickhouse-client`:
+
+```sql
+-- ClickHouse (if Storage:Analytics=ClickHouse)
+SELECT count(), max(Timestamp) FROM logs   WHERE ServiceName = 'holdfast-soak';
+SELECT count(), max(Timestamp) FROM traces WHERE ServiceName = 'holdfast-soak';
+
+-- Postgres (if Storage:Analytics=Postgres)
+SELECT count(*), max(timestamp) FROM analytics.logs   WHERE service_name = 'holdfast-soak';
+SELECT count(*), max(timestamp) FROM analytics.traces WHERE service_name = 'holdfast-soak';
+```
+
+HOL-41 will deliver a `verify.sh` that runs all these queries and prints a green/red summary.
+
+## 24-hour soak procedure
+
+1. Confirm the stack is on a fresh backend image (rebuild via `docker compose build backend` if changes have landed since last run).
+2. Snapshot baseline memory: `docker stats --no-stream > /tmp/soak-start.txt`
+3. Start the soak harness with default config: `docker compose --profile soak up -d soak`
+4. Let it run for 24 hours. Check `docker logs --tail 50 holdfast-soak` periodically.
+5. After 24h, snapshot memory again and compare: `docker stats --no-stream > /tmp/soak-end.txt`
+6. Run the verification queries and confirm rows from each scenario type.
+7. Stop the harness: `docker compose --profile soak stop soak`.
+
+Memory growth budget: < 50 MiB delta on the backend container over 24h.
+Anything more is a regression worth investigating.

--- a/tests/soak/index.mjs
+++ b/tests/soak/index.mjs
@@ -1,0 +1,177 @@
+// HOL-38 (EPIC HOL-37): soak harness entrypoint.
+//
+// Long-running container that emits ingest data to the local backend on a
+// variable-rate schedule. Designed to run for ~24 hours without operator
+// intervention. Each tick the scheduler invokes a randomly-selected scenario;
+// scenarios send to the backend via OTLP/HTTP and (in HOL-39+) the public
+// GraphQL endpoint for sessions/errors that don't go through OTLP.
+//
+// HOL-38 scope (this file): SDK boot + tick loop emitting one INFO log + one
+// trivial trace per tick, just to verify the wiring end-to-end. HOL-39 swaps
+// the placeholder scenarios for the full library; HOL-40 replaces the fixed
+// interval with a variable-rate scheduler with spike windows.
+//
+// stdout protocol: every tick prints one JSON-shaped line so a `docker logs`
+// tail is greppable. SIGTERM triggers a clean shutdown that flushes batched
+// exporter queues before exiting.
+
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
+import { Resource } from '@opentelemetry/resources'
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+} from '@opentelemetry/semantic-conventions'
+import { BatchLogRecordProcessor, LoggerProvider } from '@opentelemetry/sdk-logs'
+import { logs, SeverityNumber } from '@opentelemetry/api-logs'
+import { trace } from '@opentelemetry/api'
+
+// ── Config ──────────────────────────────────────────────────────────
+const PROJECT_ID = process.env.HOLDFAST_PROJECT_ID || '2'
+const OTLP_ENDPOINT = process.env.OTLP_ENDPOINT || 'http://backend:8082/otel'
+const BASE_INTERVAL_MS = parseInt(
+  process.env.SOAK_BASE_INTERVAL_MS || '60000',
+  10,
+)
+const SERVICE_NAME = process.env.SOAK_SERVICE_NAME || 'holdfast-soak'
+const SERVICE_VERSION = process.env.SOAK_SERVICE_VERSION || '0.0.0-soak'
+
+// ── OTel SDK ────────────────────────────────────────────────────────
+const headers = { 'x-highlight-project': PROJECT_ID }
+
+const resource = new Resource({
+  [ATTR_SERVICE_NAME]: SERVICE_NAME,
+  [ATTR_SERVICE_VERSION]: SERVICE_VERSION,
+})
+
+const sdk = new NodeSDK({
+  resource,
+  traceExporter: new OTLPTraceExporter({
+    url: `${OTLP_ENDPOINT}/v1/traces`,
+    headers,
+  }),
+})
+sdk.start()
+
+const loggerProvider = new LoggerProvider({ resource })
+loggerProvider.addLogRecordProcessor(
+  new BatchLogRecordProcessor(
+    new OTLPLogExporter({ url: `${OTLP_ENDPOINT}/v1/logs`, headers }),
+    { scheduledDelayMillis: 1_000, maxExportBatchSize: 64 },
+  ),
+)
+logs.setGlobalLoggerProvider(loggerProvider)
+
+const logger = logs.getLogger(SERVICE_NAME)
+const tracer = trace.getTracer(SERVICE_NAME)
+
+// ── Tick loop ───────────────────────────────────────────────────────
+let tickCount = 0
+let stopping = false
+
+function logEvent(payload) {
+  // One JSON line per tick — `docker logs holdfast-soak | jq -c` works directly.
+  process.stdout.write(JSON.stringify(payload) + '\n')
+}
+
+async function tick() {
+  tickCount++
+  const t0 = Date.now()
+
+  // Placeholder scenarios — HOL-39 replaces these with the real library
+  logger.emit({
+    severityNumber: SeverityNumber.INFO,
+    severityText: 'INFO',
+    body: `soak tick #${tickCount}`,
+    attributes: {
+      tick: tickCount,
+      'soak.kind': 'startup-placeholder',
+    },
+  })
+
+  tracer.startActiveSpan('soak.tick', (span) => {
+    span.setAttribute('tick', tickCount)
+    span.end()
+  })
+
+  logEvent({
+    ts: new Date().toISOString(),
+    event: 'soak.tick',
+    tick: tickCount,
+    elapsed_ms: Date.now() - t0,
+    scenarios_emitted: ['placeholder-log', 'placeholder-trace'],
+  })
+}
+
+async function loop() {
+  // Initial 'soak.started' event so operators have a single log line that
+  // confirms the container has reached the live state. Trace name + log
+  // both carry the marker so either query path finds it.
+  logger.emit({
+    severityNumber: SeverityNumber.INFO,
+    severityText: 'INFO',
+    body: 'soak.started',
+    attributes: {
+      'soak.kind': 'startup',
+      'soak.project_id': PROJECT_ID,
+      'soak.base_interval_ms': BASE_INTERVAL_MS,
+    },
+  })
+  tracer
+    .startSpan('soak.started')
+    .end()
+  logEvent({
+    ts: new Date().toISOString(),
+    event: 'soak.started',
+    config: {
+      project_id: PROJECT_ID,
+      otlp_endpoint: OTLP_ENDPOINT,
+      base_interval_ms: BASE_INTERVAL_MS,
+      service_name: SERVICE_NAME,
+    },
+  })
+
+  // Fixed-interval loop. HOL-40 replaces this with the variable-rate scheduler.
+  while (!stopping) {
+    await tick()
+    await new Promise((resolve) => setTimeout(resolve, BASE_INTERVAL_MS))
+  }
+}
+
+async function shutdown(signal) {
+  if (stopping) return
+  stopping = true
+  logEvent({
+    ts: new Date().toISOString(),
+    event: 'soak.stopping',
+    signal,
+    total_ticks: tickCount,
+  })
+  try {
+    // Flush batched exporters before exit — tests/operators expect the last
+    // few ticks to land in the analytics store.
+    await sdk.shutdown()
+    await loggerProvider.shutdown()
+  } catch (e) {
+    logEvent({
+      ts: new Date().toISOString(),
+      event: 'soak.shutdown.error',
+      error: e?.message || String(e),
+    })
+  }
+  process.exit(0)
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'))
+process.on('SIGINT', () => shutdown('SIGINT'))
+
+loop().catch((err) => {
+  logEvent({
+    ts: new Date().toISOString(),
+    event: 'soak.crash',
+    error: err?.message || String(err),
+    stack: err?.stack,
+  })
+  process.exit(1)
+})

--- a/tests/soak/package.json
+++ b/tests/soak/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "holdfast-soak",
+  "version": "0.0.0",
+  "private": true,
+  "description": "HOL-37/38 — continuous soak harness that exercises the analytics ingest surface (logs / traces / errors / sessions / metrics / events) with variable-rate scenarios. Designed to run for ~24 hours alongside the hobby stack.",
+  "type": "module",
+  "main": "index.mjs",
+  "scripts": {
+    "start": "node index.mjs"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.55.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.55.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.55.0",
+    "@opentelemetry/resources": "^1.28.0",
+    "@opentelemetry/sdk-logs": "^0.55.0",
+    "@opentelemetry/sdk-node": "^0.55.0",
+    "@opentelemetry/sdk-trace-base": "^1.28.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0"
+  }
+}

--- a/tests/soak/scenarios/.placeholder
+++ b/tests/soak/scenarios/.placeholder
@@ -1,0 +1,1 @@
+// HOL-39 placeholder — scenario library lands in the next ticket.


### PR DESCRIPTION
## Summary

Foundation for the analytics-ingest soak harness. Container boots, OTel SDK wires up, tick loop emits placeholder logs + traces, clean SIGTERM shutdown.

Follow-up tickets land the substance:
- HOL-39 — scenario library (logs / traces / errors / sessions / metrics / events)
- HOL-40 — variable-rate scheduler with spike windows
- HOL-41 — operator runbook + verification queries

## What this PR adds

- **`tests/soak/`** — new dir mirroring `tests/sample-node/`'s shape: `package.json`, `index.mjs` entrypoint, `Dockerfile`, `README.md`, `.gitignore`
- **`infra/docker/compose.soak.yml`** — overlay adding the harness behind `--profile soak` so `docker compose up` doesn't accidentally pull it in. Depends on backend healthcheck.

## Live verification

- `npm install` clean (0 vulnerabilities)
- Local `node index.mjs` produces tick events at `SOAK_BASE_INTERVAL_MS` cadence
- `docker compose --profile soak up -d` integrates cleanly with the existing stack
- `docker stop holdfast-soak` → SIGTERM handler runs, `soak.stopping` event prints, clean exit 0

## Output protocol

Each tick emits one JSON line — `docker logs -f holdfast-soak | jq -c` works directly. Special events: `soak.started`, `soak.tick`, `soak.stopping`, `soak.shutdown.error`, `soak.crash`.

## Out of scope

- Real scenario emission — placeholders for now (HOL-39)
- Variable-rate / spike-mode scheduling — fixed interval (HOL-40)
- Verification scripts (HOL-41)

Closes [HOL-38](https://yt.brewingcoder.com/issue/HOL-38). First subtask of [HOL-37](https://yt.brewingcoder.com/issue/HOL-37) (Continuous soak/load harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)