### PR TITLE
tests: soak scenario library — logs/traces/errors/sessions/metrics/events (HOL-39)

### DIFF
--- a/tests/soak/index.mjs
+++ b/tests/soak/index.mjs
@@ -1,15 +1,14 @@
-// HOL-38 (EPIC HOL-37): soak harness entrypoint.
+// HOL-37 EPIC: soak harness entrypoint.
 //
 // Long-running container that emits ingest data to the local backend on a
 // variable-rate schedule. Designed to run for ~24 hours without operator
-// intervention. Each tick the scheduler invokes a randomly-selected scenario;
-// scenarios send to the backend via OTLP/HTTP and (in HOL-39+) the public
-// GraphQL endpoint for sessions/errors that don't go through OTLP.
+// intervention. Each tick the scheduler picks a random scenario from the
+// HOL-39 scenario library; scenarios send to the backend via OTLP/HTTP.
 //
-// HOL-38 scope (this file): SDK boot + tick loop emitting one INFO log + one
-// trivial trace per tick, just to verify the wiring end-to-end. HOL-39 swaps
-// the placeholder scenarios for the full library; HOL-40 replaces the fixed
-// interval with a variable-rate scheduler with spike windows.
+// HOL-38: SDK boot + fixed-interval tick loop with placeholder scenarios.
+// HOL-39 (this file): wires the real scenario library and adds the OTel
+// metrics SDK so metrics scenarios have somewhere to write.
+// HOL-40: replaces the fixed interval with a variable-rate scheduler.
 //
 // stdout protocol: every tick prints one JSON-shaped line so a `docker logs`
 // tail is greppable. SIGTERM triggers a clean shutdown that flushes batched
@@ -18,24 +17,33 @@
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
 import { Resource } from '@opentelemetry/resources'
 import {
   ATTR_SERVICE_NAME,
   ATTR_SERVICE_VERSION,
 } from '@opentelemetry/semantic-conventions'
 import { BatchLogRecordProcessor, LoggerProvider } from '@opentelemetry/sdk-logs'
-import { logs, SeverityNumber } from '@opentelemetry/api-logs'
-import { trace } from '@opentelemetry/api'
+import {
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics'
+import { logs } from '@opentelemetry/api-logs'
+import { metrics, trace } from '@opentelemetry/api'
+
+import {
+  pickRandomScenario,
+  createMetricCache,
+  scenarioWeights,
+} from './scenarios/index.mjs'
 
 // ── Config ──────────────────────────────────────────────────────────
 const PROJECT_ID = process.env.HOLDFAST_PROJECT_ID || '2'
 const OTLP_ENDPOINT = process.env.OTLP_ENDPOINT || 'http://backend:8082/otel'
-const BASE_INTERVAL_MS = parseInt(
-  process.env.SOAK_BASE_INTERVAL_MS || '60000',
-  10,
-)
+const BASE_INTERVAL_MS = parseInt(process.env.SOAK_BASE_INTERVAL_MS || '60000', 10)
 const SERVICE_NAME = process.env.SOAK_SERVICE_NAME || 'holdfast-soak'
 const SERVICE_VERSION = process.env.SOAK_SERVICE_VERSION || '0.0.0-soak'
+const METRIC_EXPORT_MS = parseInt(process.env.SOAK_METRIC_EXPORT_MS || '15000', 10)
 
 // ── OTel SDK ────────────────────────────────────────────────────────
 const headers = { 'x-highlight-project': PROJECT_ID }
@@ -63,64 +71,70 @@ loggerProvider.addLogRecordProcessor(
 )
 logs.setGlobalLoggerProvider(loggerProvider)
 
-const logger = logs.getLogger(SERVICE_NAME)
-const tracer = trace.getTracer(SERVICE_NAME)
+// HOL-39: dedicated MeterProvider for the metrics scenario. Periodic export
+// at SOAK_METRIC_EXPORT_MS (default 15s) so the dashboard sees fresh
+// counters/gauges without flooding the wire on every tick.
+const meterProvider = new MeterProvider({
+  resource,
+  readers: [
+    new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporter({
+        url: `${OTLP_ENDPOINT}/v1/metrics`,
+        headers,
+      }),
+      exportIntervalMillis: METRIC_EXPORT_MS,
+    }),
+  ],
+})
+metrics.setGlobalMeterProvider(meterProvider)
+
+const ctx = {
+  logger: logs.getLogger(SERVICE_NAME),
+  tracer: trace.getTracer(SERVICE_NAME),
+  meter: metrics.getMeter(SERVICE_NAME),
+  metricCache: createMetricCache(),
+}
 
 // ── Tick loop ───────────────────────────────────────────────────────
 let tickCount = 0
 let stopping = false
 
 function logEvent(payload) {
-  // One JSON line per tick — `docker logs holdfast-soak | jq -c` works directly.
   process.stdout.write(JSON.stringify(payload) + '\n')
 }
 
 async function tick() {
   tickCount++
   const t0 = Date.now()
-
-  // Placeholder scenarios — HOL-39 replaces these with the real library
-  logger.emit({
-    severityNumber: SeverityNumber.INFO,
-    severityText: 'INFO',
-    body: `soak tick #${tickCount}`,
-    attributes: {
+  let scenarioName = null
+  let scenarioResult = null
+  try {
+    const { name, fn } = pickRandomScenario()
+    scenarioName = name
+    scenarioResult = fn(ctx)
+  } catch (e) {
+    // A scenario crash shouldn't tank the whole harness.
+    logEvent({
+      ts: new Date().toISOString(),
+      event: 'soak.tick.error',
       tick: tickCount,
-      'soak.kind': 'startup-placeholder',
-    },
-  })
-
-  tracer.startActiveSpan('soak.tick', (span) => {
-    span.setAttribute('tick', tickCount)
-    span.end()
-  })
+      scenario: scenarioName,
+      error: e?.message || String(e),
+    })
+    return
+  }
 
   logEvent({
     ts: new Date().toISOString(),
     event: 'soak.tick',
     tick: tickCount,
     elapsed_ms: Date.now() - t0,
-    scenarios_emitted: ['placeholder-log', 'placeholder-trace'],
+    scenario: scenarioName,
+    result: scenarioResult,
   })
 }
 
 async function loop() {
-  // Initial 'soak.started' event so operators have a single log line that
-  // confirms the container has reached the live state. Trace name + log
-  // both carry the marker so either query path finds it.
-  logger.emit({
-    severityNumber: SeverityNumber.INFO,
-    severityText: 'INFO',
-    body: 'soak.started',
-    attributes: {
-      'soak.kind': 'startup',
-      'soak.project_id': PROJECT_ID,
-      'soak.base_interval_ms': BASE_INTERVAL_MS,
-    },
-  })
-  tracer
-    .startSpan('soak.started')
-    .end()
   logEvent({
     ts: new Date().toISOString(),
     event: 'soak.started',
@@ -129,10 +143,16 @@ async function loop() {
       otlp_endpoint: OTLP_ENDPOINT,
       base_interval_ms: BASE_INTERVAL_MS,
       service_name: SERVICE_NAME,
+      metric_export_ms: METRIC_EXPORT_MS,
+      weights: scenarioWeights,
     },
   })
 
-  // Fixed-interval loop. HOL-40 replaces this with the variable-rate scheduler.
+  // Mark startup in the analytics store so a single query verifies the
+  // harness reached live state.
+  ctx.tracer.startSpan('soak.started').end()
+
+  // HOL-40 will replace this fixed loop with a variable-rate scheduler.
   while (!stopping) {
     await tick()
     await new Promise((resolve) => setTimeout(resolve, BASE_INTERVAL_MS))
@@ -149,10 +169,9 @@ async function shutdown(signal) {
     total_ticks: tickCount,
   })
   try {
-    // Flush batched exporters before exit — tests/operators expect the last
-    // few ticks to land in the analytics store.
     await sdk.shutdown()
     await loggerProvider.shutdown()
+    await meterProvider.shutdown()
   } catch (e) {
     logEvent({
       ts: new Date().toISOString(),

--- a/tests/soak/package.json
+++ b/tests/soak/package.json
@@ -12,9 +12,11 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.55.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.55.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.55.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.55.0",
     "@opentelemetry/resources": "^1.28.0",
     "@opentelemetry/sdk-logs": "^0.55.0",
+    "@opentelemetry/sdk-metrics": "^1.28.0",
     "@opentelemetry/sdk-node": "^0.55.0",
     "@opentelemetry/sdk-trace-base": "^1.28.0",
     "@opentelemetry/semantic-conventions": "^1.28.0"

--- a/tests/soak/scenarios/.placeholder
+++ b/tests/soak/scenarios/.placeholder
@@ -1,1 +1,0 @@
-// HOL-39 placeholder — scenario library lands in the next ticket.

--- a/tests/soak/scenarios/errors.mjs
+++ b/tests/soak/scenarios/errors.mjs
@@ -1,0 +1,70 @@
+import { SeverityNumber } from '@opentelemetry/api-logs'
+import { pick, weighted, randomAttributes } from './random.mjs'
+
+// 20 stable error "groups" (Type + first stack frame) so the dedup behavior
+// in error_groups gets exercised across the full soak run.
+const ERROR_GROUPS = [
+  ['TypeError', 'cannot read property of undefined', 'at processOrder (/app/orders.js:42:12)'],
+  ['TypeError', 'is not a function', 'at validateInput (/app/validate.js:18:8)'],
+  ['TypeError', 'expected string', 'at parseConfig (/app/config.js:55:22)'],
+  ['ReferenceError', 'unknown identifier', 'at runHook (/app/hooks.js:91:5)'],
+  ['ReferenceError', 'before initialization', 'at Bootstrap (/app/boot.js:12:3)'],
+  ['NetworkError', 'connection reset', 'at fetchUpstream (/app/net.js:33:9)'],
+  ['NetworkError', 'timeout exceeded', 'at apiCall (/app/api.js:48:14)'],
+  ['NetworkError', 'DNS lookup failed', 'at resolveHost (/app/dns.js:7:1)'],
+  ['RangeError', 'maximum call stack', 'at recurse (/app/recurse.js:3:10)'],
+  ['ValidationError', 'email not valid', 'at signup (/app/auth.js:67:18)'],
+  ['ValidationError', 'password too short', 'at signup (/app/auth.js:71:18)'],
+  ['ValidationError', 'amount must be positive', 'at chargeCard (/app/billing.js:88:24)'],
+  ['DatabaseError', 'unique constraint violation', 'at insertUser (/app/db/users.js:120:7)'],
+  ['DatabaseError', 'connection pool exhausted', 'at acquire (/app/db/pool.js:33:5)'],
+  ['DatabaseError', 'query timeout', 'at runQuery (/app/db/query.js:200:14)'],
+  ['AuthError', 'token expired', 'at verify (/app/auth/jwt.js:12:6)'],
+  ['AuthError', 'invalid signature', 'at verify (/app/auth/jwt.js:25:6)'],
+  ['NotFoundError', 'user not found', 'at lookupUser (/app/users.js:44:8)'],
+  ['NotFoundError', 'order does not exist', 'at fetchOrder (/app/orders.js:78:8)'],
+  ['NotFoundError', 'product unavailable', 'at fetchProduct (/app/products.js:31:8)'],
+]
+
+const RECURRENCE_TABLE = [
+  [50, 1],   // 50% of error events are a single occurrence
+  [30, 2],   // 30% are 2 in quick succession
+  [15, 5],   // 15% are 5 (a "burst")
+  [5, 20],   // 5% are 20 (an "outage" window)
+]
+
+/**
+ * Emit a backend-style error as an ERROR-severity log with the attribute
+ * bag the backend's worker can dedup on. We use the OTLP log path (rather
+ * than the public GraphQL pushBackendPayload mutation) to keep the soak
+ * harness API-key-free; this still exercises the analytics-store error
+ * surface end-to-end since the worker grouping is downstream of log
+ * ingestion in the Postgres-backend path.
+ *
+ * @param {object} ctx
+ * @param {import('@opentelemetry/api-logs').Logger} ctx.logger
+ */
+export function emitError(ctx) {
+  const [type, message, frame] = pick(ERROR_GROUPS)
+  const recurrence = weighted(RECURRENCE_TABLE)
+  const groupKey = `${type}:${frame}` // mimic the backend's grouping signature
+  const baseAttrs = randomAttributes()
+
+  for (let i = 0; i < recurrence; i++) {
+    ctx.logger.emit({
+      severityNumber: SeverityNumber.ERROR,
+      severityText: 'ERROR',
+      body: `${type}: ${message}`,
+      attributes: {
+        ...baseAttrs,
+        'log.scenario': 'errors',
+        'error.type': type,
+        'error.message': message,
+        'error.stack_top': frame,
+        'error.group_key': groupKey,
+        'error.occurrence': i + 1,
+      },
+    })
+  }
+  return { scenario: 'errors', type, recurrence }
+}

--- a/tests/soak/scenarios/events.mjs
+++ b/tests/soak/scenarios/events.mjs
@@ -1,0 +1,44 @@
+import { SeverityNumber } from '@opentelemetry/api-logs'
+import { pick, weighted, randInt, randomAttributes } from './random.mjs'
+
+const EVENT_NAMES = [
+  [25, 'page_view'],
+  [15, 'button_click'],
+  [10, 'form_submit'],
+  [10, 'feature_used'],
+  [10, 'search_query'],
+  [10, 'video_play'],
+  [10, 'cart_added'],
+  [5, 'cart_removed'],
+  [5, 'checkout_started'],
+]
+
+/**
+ * Emit a custom session event as an INFO log with the attribute schema the
+ * dashboard's events surface expects. As with sessions, the soak skips the
+ * full GraphQL pushPayload path for simplicity and tags via attribute
+ * convention so the verification queries can find them.
+ *
+ * @param {object} ctx
+ * @param {import('@opentelemetry/api-logs').Logger} ctx.logger
+ */
+export function emitEvent(ctx) {
+  const eventName = weighted(EVENT_NAMES)
+  const attrs = randomAttributes()
+
+  ctx.logger.emit({
+    severityNumber: SeverityNumber.INFO,
+    severityText: 'INFO',
+    body: `event: ${eventName}`,
+    attributes: {
+      ...attrs,
+      'log.scenario': 'events',
+      'event.name': eventName,
+      'event.session_id': `soak-session-${randInt(1, 1000)}`,
+      'event.user_id': `soak-user-${randInt(1, 1000)}`,
+      'event.timestamp_ms': Date.now(),
+    },
+  })
+
+  return { scenario: 'events', name: eventName }
+}

--- a/tests/soak/scenarios/index.mjs
+++ b/tests/soak/scenarios/index.mjs
@@ -1,0 +1,59 @@
+// Public entrypoint for the scenario library — index.mjs imports
+// `pickRandomScenario` and calls the returned function with the OTel context.
+
+import { weighted } from './random.mjs'
+import { emitLog } from './logs.mjs'
+import { emitTrace } from './traces.mjs'
+import { emitError } from './errors.mjs'
+import { emitSession } from './sessions.mjs'
+import { emitEvent } from './events.mjs'
+import { emitMetric, createMetricCache } from './metrics.mjs'
+
+// Realistic distribution: logs dominate, sessions/events trail.
+// Override via SOAK_WEIGHTS env var (comma-separated key=weight pairs):
+//   SOAK_WEIGHTS=logs=80,traces=10,metrics=5,errors=5
+const DEFAULT_WEIGHTS = {
+  logs: 40,
+  traces: 20,
+  metrics: 15,
+  errors: 10,
+  sessions: 10,
+  events: 5,
+}
+
+const SCENARIO_FUNCS = {
+  logs: emitLog,
+  traces: emitTrace,
+  metrics: emitMetric,
+  errors: emitError,
+  sessions: emitSession,
+  events: emitEvent,
+}
+
+function parseWeights(envValue) {
+  if (!envValue) return DEFAULT_WEIGHTS
+  const out = { ...DEFAULT_WEIGHTS }
+  for (const part of envValue.split(',')) {
+    const [k, v] = part.trim().split('=')
+    if (k && v && k in DEFAULT_WEIGHTS) {
+      const n = parseFloat(v)
+      if (Number.isFinite(n) && n >= 0) out[k] = n
+    }
+  }
+  return out
+}
+
+const weights = parseWeights(process.env.SOAK_WEIGHTS)
+const TABLE = Object.entries(weights)
+  .filter(([, w]) => w > 0)
+  .map(([k, w]) => [w, k])
+
+/**
+ * Pick one scenario name per the configured weights, then return its emit fn.
+ */
+export function pickRandomScenario() {
+  const name = weighted(TABLE)
+  return { name, fn: SCENARIO_FUNCS[name] }
+}
+
+export { createMetricCache, weights as scenarioWeights }

--- a/tests/soak/scenarios/logs.mjs
+++ b/tests/soak/scenarios/logs.mjs
@@ -1,0 +1,71 @@
+import { SeverityNumber } from '@opentelemetry/api-logs'
+import { pick, weighted, randomAttributes } from './random.mjs'
+
+// Severity distribution: realistic skew toward INFO/DEBUG with occasional WARN/ERROR.
+const SEVERITY_TABLE = [
+  [50, { number: SeverityNumber.INFO,  text: 'INFO' }],
+  [25, { number: SeverityNumber.DEBUG, text: 'DEBUG' }],
+  [12, { number: SeverityNumber.WARN,  text: 'WARN' }],
+  [10, { number: SeverityNumber.ERROR, text: 'ERROR' }],
+  [3,  { number: SeverityNumber.FATAL, text: 'FATAL' }],
+]
+
+const BODIES = {
+  INFO: [
+    'request handled successfully',
+    'user signed in',
+    'cache hit',
+    'background job completed',
+    'feature flag enabled for cohort',
+    'metric flushed',
+  ],
+  DEBUG: [
+    'cache miss; fetching from upstream',
+    'rate limiter check passed',
+    'feature lookup',
+    'query plan chosen',
+    'middleware completed',
+  ],
+  WARN: [
+    'request rate approaching threshold',
+    'slow database query',
+    'fallback path used',
+    'config value missing; using default',
+    'deprecated endpoint hit',
+  ],
+  ERROR: [
+    'database query failed',
+    'upstream service unavailable',
+    'authentication failed',
+    'validation error in request body',
+    'payment provider rejected charge',
+  ],
+  FATAL: [
+    'process out of memory',
+    'unable to bind to required port',
+    'critical dependency unreachable on startup',
+  ],
+}
+
+/**
+ * Emit a log row with random severity, body, and attributes.
+ *
+ * @param {object} ctx
+ * @param {import('@opentelemetry/api-logs').Logger} ctx.logger
+ * @returns {{ scenario: 'logs', severity: string }}
+ */
+export function emitLog(ctx) {
+  const sev = weighted(SEVERITY_TABLE)
+  const body = pick(BODIES[sev.text])
+  const attrs = randomAttributes()
+  attrs['log.scenario'] = 'logs'
+
+  ctx.logger.emit({
+    severityNumber: sev.number,
+    severityText: sev.text,
+    body,
+    attributes: attrs,
+  })
+
+  return { scenario: 'logs', severity: sev.text }
+}

--- a/tests/soak/scenarios/metrics.mjs
+++ b/tests/soak/scenarios/metrics.mjs
@@ -1,0 +1,92 @@
+import { pick, weighted, randInt, logNormal, randomAttributes } from './random.mjs'
+
+// Metric kinds: counter (always-increasing), gauge (point-in-time), histogram (latency-shaped).
+const METRIC_KINDS = [
+  [40, 'counter'],
+  [30, 'gauge'],
+  [30, 'histogram'],
+]
+
+const COUNTER_NAMES = [
+  'request_count', 'error_count', 'cache_hit_count',
+  'queue_processed_count', 'auth_success_count',
+]
+const GAUGE_NAMES = [
+  'cpu_percent', 'memory_used_bytes', 'queue_depth',
+  'active_connections', 'pool_idle_count',
+]
+const HISTOGRAM_NAMES = [
+  'request_duration_ms', 'db_query_duration_ms',
+  'queue_processing_ms', 'render_duration_ms',
+]
+
+/**
+ * Emit one metric data point. Routes through the OTel meter provider that
+ * index.mjs sets up — counters and histograms record observations; gauges
+ * use a synchronous gauge instrument.
+ *
+ * @param {object} ctx
+ * @param {import('@opentelemetry/api').Meter} ctx.meter
+ */
+export function emitMetric(ctx) {
+  const kind = weighted(METRIC_KINDS)
+  const attrs = randomAttributes()
+  attrs['metric.scenario'] = 'metrics'
+
+  switch (kind) {
+    case 'counter': {
+      const name = pick(COUNTER_NAMES)
+      const c = ctx.metricCache.counters.get(name) ?? ctx.meter.createCounter(name)
+      ctx.metricCache.counters.set(name, c)
+      c.add(randInt(1, 25), attrs)
+      return { scenario: 'metrics', kind, name }
+    }
+    case 'gauge': {
+      const name = pick(GAUGE_NAMES)
+      // Gauge: use observable gauge with a fresh callback each time
+      // (simpler than the synchronous-gauge API which isn't stable in 0.55)
+      const g = ctx.metricCache.gauges.get(name) ?? ctx.meter.createObservableGauge(name)
+      if (!ctx.metricCache.gauges.has(name)) {
+        const samples = []
+        g.addCallback((result) => {
+          while (samples.length > 0) {
+            const s = samples.shift()
+            result.observe(s.value, s.attrs)
+          }
+        })
+        ctx.metricCache.gauges.set(name, { instrument: g, samples })
+      }
+      const cached = ctx.metricCache.gauges.get(name)
+      const value = name === 'cpu_percent' ? logNormal(35, 0.4)
+                  : name === 'memory_used_bytes' ? logNormal(500_000_000, 0.3)
+                  : randInt(0, 200)
+      cached.samples.push({ value, attrs })
+      return { scenario: 'metrics', kind, name }
+    }
+    case 'histogram': {
+      const name = pick(HISTOGRAM_NAMES)
+      const h = ctx.metricCache.histograms.get(name) ?? ctx.meter.createHistogram(name)
+      ctx.metricCache.histograms.set(name, h)
+      // Latency-shaped distribution: median ~50ms, log-normal tail
+      const median = name === 'render_duration_ms' ? 16
+                  : name === 'db_query_duration_ms' ? 5
+                  : 50
+      h.record(logNormal(median, 0.7), attrs)
+      return { scenario: 'metrics', kind, name }
+    }
+  }
+}
+
+/**
+ * Set up the metric cache structure that emitMetric closes over. Called once
+ * at startup by index.mjs.
+ */
+export function createMetricCache() {
+  return {
+    counters: new Map(),
+    // gauges store both the instrument and a samples queue the observable
+    // callback drains on every collection cycle
+    gauges: new Map(),
+    histograms: new Map(),
+  }
+}

--- a/tests/soak/scenarios/random.mjs
+++ b/tests/soak/scenarios/random.mjs
@@ -1,0 +1,80 @@
+// Small RNG helpers shared across scenario modules.
+
+/**
+ * Pick a random element from an array.
+ */
+export function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)]
+}
+
+/**
+ * Weighted random: pass an array of [weight, value] pairs. Returns one value
+ * proportional to its weight.
+ */
+export function weighted(pairs) {
+  const total = pairs.reduce((sum, [w]) => sum + w, 0)
+  let r = Math.random() * total
+  for (const [w, v] of pairs) {
+    r -= w
+    if (r <= 0) return v
+  }
+  return pairs[pairs.length - 1][1]
+}
+
+/**
+ * Random integer in [min, max] inclusive.
+ */
+export function randInt(min, max) {
+  return min + Math.floor(Math.random() * (max - min + 1))
+}
+
+/**
+ * Random float in [min, max).
+ */
+export function randFloat(min, max) {
+  return min + Math.random() * (max - min)
+}
+
+/**
+ * Box-Muller log-normal-ish skew for latency-shaped distributions.
+ * Returns a positive number with median ~`median` and right-tail skew.
+ */
+export function logNormal(median, sigma = 0.6) {
+  const u = 1 - Math.random()
+  const v = 1 - Math.random()
+  const z = Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v)
+  return median * Math.exp(sigma * z)
+}
+
+/**
+ * Realistic-looking attribute dimensions for tagging logs/traces/metrics.
+ * These are intentionally bounded (low cardinality) so the soak doesn't
+ * blow up the analytics catalog tables.
+ */
+export const dimensions = {
+  service: ['api', 'web', 'worker', 'auth-service', 'billing-service'],
+  environment: ['prod', 'staging', 'dev'],
+  region: ['us-east-1', 'us-west-2', 'eu-west-1', 'ap-southeast-2'],
+  feature: [
+    'checkout', 'login', 'signup', 'profile', 'search',
+    'dashboard', 'api', 'reports', 'admin', 'health',
+  ],
+  http_method: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
+  http_route: [
+    '/api/users', '/api/orders', '/api/products', '/api/auth/login',
+    '/api/billing/charge', '/api/reports', '/api/health',
+  ],
+}
+
+/**
+ * Build a random attribute bag of size 3-8 keys drawn from the dimension catalog.
+ */
+export function randomAttributes() {
+  const keys = ['service', 'environment', 'region', 'feature']
+  const optional = ['http_method', 'http_route']
+  const optCount = randInt(0, optional.length)
+  const chosen = [...keys, ...optional.slice(0, optCount)]
+  const out = {}
+  for (const k of chosen) out[k.replace('_', '.')] = pick(dimensions[k])
+  return out
+}

--- a/tests/soak/scenarios/sessions.mjs
+++ b/tests/soak/scenarios/sessions.mjs
@@ -1,0 +1,78 @@
+import { SeverityNumber } from '@opentelemetry/api-logs'
+import { pick, weighted, randInt, randomAttributes } from './random.mjs'
+
+// Realistic-ish browser/OS distribution; matches what dashboard sees in real traffic
+const BROWSERS = [
+  [55, ['Chrome', '120.0.6099.71']],
+  [20, ['Safari', '17.1']],
+  [15, ['Firefox', '120.0.1']],
+  [5, ['Edge', '120.0.2210.61']],
+  [5, ['Opera', '105.0.4970.34']],
+]
+
+const OS_TABLE = [
+  [50, ['macOS', '14.1.2']],
+  [25, ['Windows', '11.0.22631']],
+  [15, ['iOS', '17.1.1']],
+  [5, ['Android', '14']],
+  [5, ['Linux', '6.5']],
+]
+
+const COUNTRIES = [
+  [40, 'US'],
+  [15, 'GB'],
+  [10, 'DE'],
+  [10, 'CA'],
+  [10, 'AU'],
+  [5, 'JP'],
+  [5, 'BR'],
+  [5, 'IN'],
+]
+
+/**
+ * Emit a "session" trace — the soak harness can't actually create sessions
+ * via the public GraphQL surface (that requires an API key + full pushPayload
+ * lifecycle), so we simulate the session in the trace store with a
+ * `session.start` span carrying the attributes the dashboard expects on a
+ * session. This still exercises the analytics-store session-data surface
+ * (analytics.sessions for PG, default.sessions for CH) once the worker's
+ * session-event consumer maps the OTLP span into a session row in HOL-39+.
+ *
+ * For now, the soak verification queries should look at traces with
+ * `session.scenario=sessions` to confirm volume.
+ *
+ * @param {object} ctx
+ * @param {import('@opentelemetry/api').Tracer} ctx.tracer
+ */
+export function emitSession(ctx) {
+  const [browserName, browserVersion] = weighted(BROWSERS)
+  const [osName, osVersion] = weighted(OS_TABLE)
+  const country = weighted(COUNTRIES)
+  const attrs = randomAttributes()
+
+  const isRageClick = Math.random() < 0.04
+  const hasErrors = Math.random() < 0.12
+  const length = randInt(5, 600) // seconds
+
+  ctx.tracer.startActiveSpan(
+    'session.start',
+    {
+      attributes: {
+        ...attrs,
+        'session.scenario': 'sessions',
+        'browser.name': browserName,
+        'browser.version': browserVersion,
+        'os.name': osName,
+        'os.version': osVersion,
+        'geo.country': country,
+        'session.has_rage_clicks': isRageClick,
+        'session.has_errors': hasErrors,
+        'session.length_seconds': length,
+        'session.identifier': `soak-user-${randInt(1, 1000)}`,
+      },
+    },
+    (span) => span.end(),
+  )
+
+  return { scenario: 'sessions', browser: browserName, country }
+}

--- a/tests/soak/scenarios/traces.mjs
+++ b/tests/soak/scenarios/traces.mjs
@@ -1,0 +1,102 @@
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api'
+import {
+  pick,
+  weighted,
+  randInt,
+  logNormal,
+  randomAttributes,
+} from './random.mjs'
+
+const SHAPE_TABLE = [
+  [50, 'single'],   // one root span (e.g. cron tick)
+  [30, 'two-level'], // root + 3-5 children
+  [15, 'tree'],      // 4-level tree, 8-15 spans total
+  [5,  'tree-with-error'], // tree with a deliberate ERROR span
+]
+
+const OPERATIONS = [
+  'http.request',
+  'db.query',
+  'cache.get',
+  'cache.set',
+  'queue.publish',
+  'queue.consume',
+  'rpc.call',
+  'session.process',
+]
+
+/**
+ * Emit a trace span tree of varying depth. ~10% of spans get a synthetic
+ * exception event so the dashboard's error-span flag is exercised.
+ *
+ * @param {object} ctx
+ * @param {import('@opentelemetry/api').Tracer} ctx.tracer
+ */
+export function emitTrace(ctx) {
+  const shape = weighted(SHAPE_TABLE)
+  const rootName = pick(OPERATIONS)
+  const baseAttrs = randomAttributes()
+  baseAttrs['trace.scenario'] = 'traces'
+  baseAttrs['trace.shape'] = shape
+
+  ctx.tracer.startActiveSpan(
+    rootName,
+    {
+      kind: SpanKind.SERVER,
+      attributes: baseAttrs,
+    },
+    (root) => {
+      try {
+        // Simulate latency
+        busyWait(logNormal(2_000_000)) // ~2ms median, log-normal tail
+
+        if (shape === 'single') return
+
+        const children = shape === 'two-level' ? randInt(3, 5) : randInt(2, 4)
+        for (let i = 0; i < children; i++) {
+          emitChild(ctx.tracer, /* depth */ shape === 'tree' || shape === 'tree-with-error' ? 1 : 0, shape === 'tree-with-error' && i === 0)
+        }
+
+        if (shape === 'tree-with-error') {
+          // Make sure at least one branch has an error
+          root.setStatus({ code: SpanStatusCode.ERROR, message: 'synthetic-error' })
+          root.recordException(new Error('synthetic soak error'))
+        }
+      } finally {
+        root.end()
+      }
+    },
+  )
+
+  return { scenario: 'traces', shape }
+}
+
+function emitChild(tracer, depth, forceError) {
+  const name = pick(OPERATIONS)
+  const isError = forceError || Math.random() < 0.07
+  tracer.startActiveSpan(name, { kind: SpanKind.INTERNAL }, (span) => {
+    try {
+      busyWait(logNormal(500_000))
+      // 60% chance of recursing one more level
+      if (depth < 3 && Math.random() < 0.6) {
+        const grandkids = randInt(1, 3)
+        for (let i = 0; i < grandkids; i++) emitChild(tracer, depth + 1, false)
+      }
+      if (isError) {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: 'synthetic child error' })
+        span.recordException(new Error(`error in ${name}`))
+      }
+    } finally {
+      span.end()
+    }
+  })
+}
+
+function busyWait(nanoseconds) {
+  // Tight loop so the trace duration is non-zero — `process.hrtime.bigint`
+  // gives us nanosecond precision; OTel coerces span durations from
+  // performance.now() so we just need elapsed real time.
+  const start = process.hrtime.bigint()
+  const target = start + BigInt(Math.floor(nanoseconds))
+  while (process.hrtime.bigint() < target) { /* busy */ }
+}


### PR DESCRIPTION
## Summary

Real implementation for the six scenario modules the soak harness picks from on each tick. HOL-38 shipped placeholders; this PR replaces them with the full library.

## What this PR adds

- **`scenarios/random.mjs`** — shared RNG helpers + low-cardinality dimension catalog so scenarios produce realistic-looking telemetry without exploding the analytics catalog tables over a 24h run.
- **`scenarios/logs.mjs`** — weighted severity (50% INFO / 25% DEBUG / 12% WARN / 10% ERROR / 3% FATAL), per-severity message banks, random attributes
- **`scenarios/traces.mjs`** — span trees of 4 shapes (single, two-level, four-level tree, tree-with-error). 7% per-span chance of carrying an error event.
- **`scenarios/errors.mjs`** — cycles through 20 stable `(type, message, stack)` groups so dedup is exercised. Recurrence pattern (1/2/5/20 events) simulates the natural "error burst" shape.
- **`scenarios/sessions.mjs`** — `session.start` spans with realistic browser/OS/geo distribution. 4% rage-click rate, 12% has_errors.
- **`scenarios/events.mjs`** — custom session events (page_view, button_click, form_submit, etc.) as INFO logs with the dashboard's events-surface attribute schema.
- **`scenarios/metrics.mjs`** — counters (always-increasing), observable gauges (log-normal distribution for CPU/memory), histograms (latency-shaped). Instruments cached per name across ticks.
- **`scenarios/index.mjs`** — `pickRandomScenario()` with weighted selection. Default weights overridable via `SOAK_WEIGHTS` env var (e.g. `logs=80,traces=10`).
- **`index.mjs`** — wires the library + adds the OTel `MeterProvider` so metrics have somewhere to write. Tick output now includes the picked scenario name + its result.
- **`package.json`** — adds `@opentelemetry/exporter-metrics-otlp-http` + `sdk-metrics`.

## Verified live in compose

20-tick run with `SOAK_BASE_INTERVAL_MS=500`:
- All six scenarios fire across the run
- Distribution roughly matches configured weights
- `errors` produces visible bursts (`recurrence=5` observed)
- Container survives `docker stop` (SIGTERM) with full flush

## Out of scope

- Variable-rate scheduler with spike windows — HOL-40 (still fixed-interval here)
- Operator runbook + verification queries — HOL-41

Closes [HOL-39](https://yt.brewingcoder.com/issue/HOL-39). Second-of-four subtasks of [HOL-37](https://yt.brewingcoder.com/issue/HOL-37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)