### PR TITLE
tests: variable-rate scheduler with spike windows for soak harness (HOL-40)

### DIFF
--- a/tests/soak/index.mjs
+++ b/tests/soak/index.mjs
@@ -36,11 +36,21 @@ import {
   createMetricCache,
   scenarioWeights,
 } from './scenarios/index.mjs'
+import { createScheduler } from './scheduler.mjs'
 
 // ── Config ──────────────────────────────────────────────────────────
 const PROJECT_ID = process.env.HOLDFAST_PROJECT_ID || '2'
 const OTLP_ENDPOINT = process.env.OTLP_ENDPOINT || 'http://backend:8082/otel'
 const BASE_INTERVAL_MS = parseInt(process.env.SOAK_BASE_INTERVAL_MS || '60000', 10)
+// HOL-40 spike-mode tuning. Defaults: 5s ticks during a 5-15min spike,
+// occurring every 25-45min outside spike windows.
+const SPIKE_INTERVAL_MS = parseInt(process.env.SOAK_SPIKE_INTERVAL_MS || '5000', 10)
+const SPIKE_MIN_DURATION_MS = parseInt(process.env.SOAK_SPIKE_MIN_DURATION_MS || `${5 * 60_000}`, 10)
+const SPIKE_MAX_DURATION_MS = parseInt(process.env.SOAK_SPIKE_MAX_DURATION_MS || `${15 * 60_000}`, 10)
+const SPIKE_MIN_GAP_MS = parseInt(process.env.SOAK_SPIKE_MIN_GAP_MS || `${25 * 60_000}`, 10)
+const SPIKE_MAX_GAP_MS = parseInt(process.env.SOAK_SPIKE_MAX_GAP_MS || `${45 * 60_000}`, 10)
+const SUMMARY_INTERVAL_MS = parseInt(process.env.SOAK_SUMMARY_INTERVAL_MS || `${5 * 60_000}`, 10)
+const DISABLE_SPIKES = process.env.SOAK_DISABLE_SPIKES === '1'
 const SERVICE_NAME = process.env.SOAK_SERVICE_NAME || 'holdfast-soak'
 const SERVICE_VERSION = process.env.SOAK_SERVICE_VERSION || '0.0.0-soak'
 const METRIC_EXPORT_MS = parseInt(process.env.SOAK_METRIC_EXPORT_MS || '15000', 10)
@@ -95,44 +105,68 @@ const ctx = {
   metricCache: createMetricCache(),
 }
 
-// ── Tick loop ───────────────────────────────────────────────────────
+// ── Scheduler-driven tick loop ──────────────────────────────────────
 let tickCount = 0
-let stopping = false
+let totalEvents = 0
 
 function logEvent(payload) {
   process.stdout.write(JSON.stringify(payload) + '\n')
 }
 
-async function tick() {
+/**
+ * Per-tick emit callback the scheduler invokes. Emits `burstCount` events
+ * each from a freshly-picked random scenario, returns the per-event names
+ * so the scheduler's summary tracker can roll them up.
+ */
+async function emitBurst({ inSpike, burstCount }) {
   tickCount++
   const t0 = Date.now()
-  let scenarioName = null
-  let scenarioResult = null
-  try {
-    const { name, fn } = pickRandomScenario()
-    scenarioName = name
-    scenarioResult = fn(ctx)
-  } catch (e) {
-    // A scenario crash shouldn't tank the whole harness.
-    logEvent({
-      ts: new Date().toISOString(),
-      event: 'soak.tick.error',
-      tick: tickCount,
-      scenario: scenarioName,
-      error: e?.message || String(e),
-    })
-    return
+  const results = []
+  for (let i = 0; i < burstCount; i++) {
+    let scenarioName = null
+    try {
+      const { name, fn } = pickRandomScenario()
+      scenarioName = name
+      const result = fn(ctx)
+      results.push({ name: scenarioName, result })
+    } catch (e) {
+      logEvent({
+        ts: new Date().toISOString(),
+        event: 'soak.scenario.error',
+        tick: tickCount,
+        scenario: scenarioName,
+        error: e?.message || String(e),
+      })
+    }
   }
-
+  totalEvents += results.length
+  // One concise log per tick — the scheduler summary covers the per-scenario rollup.
   logEvent({
     ts: new Date().toISOString(),
     event: 'soak.tick',
     tick: tickCount,
+    burst: burstCount,
+    in_spike: inSpike,
     elapsed_ms: Date.now() - t0,
-    scenario: scenarioName,
-    result: scenarioResult,
+    scenarios: results.map((r) => r.name),
   })
+  return results
 }
+
+const scheduler = createScheduler(
+  {
+    baseIntervalMs: BASE_INTERVAL_MS,
+    spikeIntervalMs: SPIKE_INTERVAL_MS,
+    spikeMinDurationMs: SPIKE_MIN_DURATION_MS,
+    spikeMaxDurationMs: SPIKE_MAX_DURATION_MS,
+    spikeMinGapMs: SPIKE_MIN_GAP_MS,
+    spikeMaxGapMs: SPIKE_MAX_GAP_MS,
+    summaryIntervalMs: SUMMARY_INTERVAL_MS,
+    disableSpikes: DISABLE_SPIKES,
+    logEvent,
+  },
+  emitBurst,
+)
 
 async function loop() {
   logEvent({
@@ -142,6 +176,13 @@ async function loop() {
       project_id: PROJECT_ID,
       otlp_endpoint: OTLP_ENDPOINT,
       base_interval_ms: BASE_INTERVAL_MS,
+      spike_interval_ms: SPIKE_INTERVAL_MS,
+      spike_min_duration_ms: SPIKE_MIN_DURATION_MS,
+      spike_max_duration_ms: SPIKE_MAX_DURATION_MS,
+      spike_min_gap_ms: SPIKE_MIN_GAP_MS,
+      spike_max_gap_ms: SPIKE_MAX_GAP_MS,
+      summary_interval_ms: SUMMARY_INTERVAL_MS,
+      disable_spikes: DISABLE_SPIKES,
       service_name: SERVICE_NAME,
       metric_export_ms: METRIC_EXPORT_MS,
       weights: scenarioWeights,
@@ -152,21 +193,20 @@ async function loop() {
   // harness reached live state.
   ctx.tracer.startSpan('soak.started').end()
 
-  // HOL-40 will replace this fixed loop with a variable-rate scheduler.
-  while (!stopping) {
-    await tick()
-    await new Promise((resolve) => setTimeout(resolve, BASE_INTERVAL_MS))
-  }
+  await scheduler.run()
 }
 
+let shuttingDown = false
 async function shutdown(signal) {
-  if (stopping) return
-  stopping = true
+  if (shuttingDown) return
+  shuttingDown = true
+  scheduler.requestStop()
   logEvent({
     ts: new Date().toISOString(),
     event: 'soak.stopping',
     signal,
     total_ticks: tickCount,
+    total_events: totalEvents,
   })
   try {
     await sdk.shutdown()

--- a/tests/soak/scheduler.mjs
+++ b/tests/soak/scheduler.mjs
@@ -1,0 +1,189 @@
+// HOL-40: variable-rate scheduler with spike windows.
+//
+// Replaces the fixed-interval tick loop from HOL-38/39. Two layers of
+// randomness:
+//
+// 1. Per-tick burst: each tick emits 1 / 2-3 / 5-10 / 20-50 events with
+//    weighted probability. This produces bursty traffic at all times,
+//    even outside the macro-spike windows, so the analytics store has to
+//    handle inserts in clumps rather than nicely spaced singles.
+//
+// 2. Macro-spike windows: every ~30 minutes (poisson-ish via random gap)
+//    a 5-15 minute window opens where:
+//    - the base interval drops to SOAK_SPIKE_INTERVAL_MS (default 5s)
+//    - the per-tick burst distribution shifts toward the high end
+//    Mirrors a real production traffic burst (cron alignment, deploy push,
+//    feature launch, etc.). Operators can disable spikes via
+//    SOAK_DISABLE_SPIKES=1.
+//
+// Telemetry: every 5 minutes the scheduler emits a "soak.summary" line
+// reporting the last window's totals + spike state. Operators tail
+// `docker logs` and grep for `summary` to confirm the harness is
+// generating the expected mix.
+
+import { weighted, randInt } from './scenarios/random.mjs'
+
+// Burst distribution. Each tick rolls one of these.
+const BURST_TABLE_NORMAL = [
+  [50, () => 1],
+  [30, () => randInt(2, 3)],
+  [15, () => randInt(5, 10)],
+  [5,  () => randInt(20, 50)],
+]
+// During a macro-spike window we shift the distribution toward the high end.
+const BURST_TABLE_SPIKE = [
+  [10, () => 1],
+  [25, () => randInt(2, 3)],
+  [35, () => randInt(5, 10)],
+  [30, () => randInt(20, 50)],
+]
+
+/**
+ * @typedef {object} SchedulerConfig
+ * @property {number} baseIntervalMs       - tick interval outside spikes (default SOAK_BASE_INTERVAL_MS)
+ * @property {number} spikeIntervalMs      - tick interval during spikes (default 5_000)
+ * @property {number} spikeMinDurationMs   - minimum spike length (default 5 min)
+ * @property {number} spikeMaxDurationMs   - maximum spike length (default 15 min)
+ * @property {number} spikeMinGapMs        - minimum quiet window between spikes (default 25 min)
+ * @property {number} spikeMaxGapMs        - maximum quiet window between spikes (default 45 min)
+ * @property {number} summaryIntervalMs    - how often to emit summary lines (default 5 min)
+ * @property {boolean} disableSpikes       - if true, never enter spike mode
+ * @property {(payload: object) => void} logEvent - stdout protocol writer
+ */
+
+/**
+ * @typedef {object} TickContext - per-tick state passed to the emit callback
+ * @property {boolean} inSpike      - whether the scheduler is currently in a macro-spike window
+ * @property {number}  burstCount   - number of events to emit this tick
+ */
+
+/**
+ * Run the scheduler. `emit(ctx)` is called once per scheduled tick; it should
+ * synchronously emit `ctx.burstCount` events. The scheduler handles all the
+ * timing, spike logic, and summary reporting.
+ *
+ * Returns a promise that resolves when `requestStop()` causes the loop to exit.
+ *
+ * @param {SchedulerConfig} config
+ * @param {(ctx: TickContext) => Promise<{name: string}[]>} emit  - returns array of {name} for each event emitted
+ * @returns {{ run: () => Promise<void>, requestStop: () => void }}
+ */
+export function createScheduler(config, emit) {
+  const cfg = {
+    baseIntervalMs: 60_000,
+    spikeIntervalMs: 5_000,
+    spikeMinDurationMs: 5 * 60_000,
+    spikeMaxDurationMs: 15 * 60_000,
+    spikeMinGapMs: 25 * 60_000,
+    spikeMaxGapMs: 45 * 60_000,
+    summaryIntervalMs: 5 * 60_000,
+    disableSpikes: false,
+    logEvent: () => {},
+    ...config,
+  }
+
+  let stopping = false
+
+  // Spike state — null means we're outside a window. Otherwise holds the
+  // wall-clock end time for the current spike.
+  let spikeEndsAt = null
+  let nextSpikeStartsAt = cfg.disableSpikes
+    ? Number.POSITIVE_INFINITY
+    : Date.now() + randInt(cfg.spikeMinGapMs, cfg.spikeMaxGapMs)
+
+  // Counters for the 5-min summary. Reset after each summary tick.
+  const window = {
+    startedAt: Date.now(),
+    ticks: 0,
+    events: 0,
+    spikeTicks: 0,
+    perScenario: Object.create(null),
+  }
+
+  function shouldEnterSpike() {
+    return !cfg.disableSpikes && spikeEndsAt === null && Date.now() >= nextSpikeStartsAt
+  }
+
+  function shouldExitSpike() {
+    return spikeEndsAt !== null && Date.now() >= spikeEndsAt
+  }
+
+  function enterSpike() {
+    const duration = randInt(cfg.spikeMinDurationMs, cfg.spikeMaxDurationMs)
+    spikeEndsAt = Date.now() + duration
+    cfg.logEvent({
+      ts: new Date().toISOString(),
+      event: 'soak.spike.start',
+      duration_ms: duration,
+      ends_at: new Date(spikeEndsAt).toISOString(),
+    })
+  }
+
+  function exitSpike() {
+    spikeEndsAt = null
+    nextSpikeStartsAt = Date.now() + randInt(cfg.spikeMinGapMs, cfg.spikeMaxGapMs)
+    cfg.logEvent({
+      ts: new Date().toISOString(),
+      event: 'soak.spike.end',
+      next_spike_at: new Date(nextSpikeStartsAt).toISOString(),
+    })
+  }
+
+  function emitSummary() {
+    const elapsed = Date.now() - window.startedAt
+    cfg.logEvent({
+      ts: new Date().toISOString(),
+      event: 'soak.summary',
+      window_ms: elapsed,
+      ticks: window.ticks,
+      events: window.events,
+      spike_ticks: window.spikeTicks,
+      per_scenario: { ...window.perScenario },
+      currently_in_spike: spikeEndsAt !== null,
+    })
+    // Reset window
+    window.startedAt = Date.now()
+    window.ticks = 0
+    window.events = 0
+    window.spikeTicks = 0
+    for (const k of Object.keys(window.perScenario)) delete window.perScenario[k]
+  }
+
+  async function run() {
+    let lastSummaryAt = Date.now()
+
+    while (!stopping) {
+      // Spike state transitions
+      if (shouldEnterSpike()) enterSpike()
+      else if (shouldExitSpike()) exitSpike()
+
+      const inSpike = spikeEndsAt !== null
+      const burstFn = weighted(inSpike ? BURST_TABLE_SPIKE : BURST_TABLE_NORMAL)
+      const burstCount = burstFn()
+
+      const results = await emit({ inSpike, burstCount })
+
+      // Counters for summary
+      window.ticks++
+      window.events += burstCount
+      if (inSpike) window.spikeTicks++
+      for (const r of results || []) {
+        const name = r?.name || 'unknown'
+        window.perScenario[name] = (window.perScenario[name] || 0) + 1
+      }
+
+      if (Date.now() - lastSummaryAt >= cfg.summaryIntervalMs) {
+        emitSummary()
+        lastSummaryAt = Date.now()
+      }
+
+      const interval = inSpike ? cfg.spikeIntervalMs : cfg.baseIntervalMs
+      await new Promise((resolve) => setTimeout(resolve, interval))
+    }
+
+    // One final summary on shutdown so operators see the last window's stats.
+    if (window.ticks > 0) emitSummary()
+  }
+
+  return { run, requestStop: () => { stopping = true } }
+}


### PR DESCRIPTION
## Summary

Replaces HOL-38/39's fixed-interval tick loop with a two-layer randomness model that produces bursty, realistic traffic and periodic spike windows.

## How it works

1. **Per-tick burst** (always-on): 50% / 30% / 15% / 5% chance of emitting 1 / 2-3 / 5-10 / 20-50 events.
2. **Macro-spike windows** (every ~25-45 minutes): tick interval drops from 60s base to 5s, burst distribution shifts toward the high end (10% / 25% / 35% / 30%). Each spike lasts 5-15 minutes. Mirrors real production traffic bursts.

## What this PR adds

- **`scheduler.mjs`** — `createScheduler()` factory encapsulating the timing loop, spike state machine, summary tracker, and clean shutdown via `requestStop()`. All knobs configurable.
- **`index.mjs`** — `while (!stopping)` loop replaced with scheduler invocation. The per-tick `emit` callback receives `{inSpike, burstCount}` and emits `burstCount` events.
- **5-minute summary lines** — `soak.summary` event with per-scenario rollup so operators get a glanceable health view from `docker logs | grep summary`.
- **Spike state events** — `soak.spike.start` (duration + ends_at) and `soak.spike.end` (next_spike_at).

### New env vars
| Var | Default | Purpose |
|---|---|---|
| `SOAK_SPIKE_INTERVAL_MS` | 5000 | tick interval during spikes |
| `SOAK_SPIKE_MIN_DURATION_MS` | 300_000 | minimum spike length (5 min) |
| `SOAK_SPIKE_MAX_DURATION_MS` | 900_000 | maximum spike length (15 min) |
| `SOAK_SPIKE_MIN_GAP_MS` | 1_500_000 | minimum quiet window (25 min) |
| `SOAK_SPIKE_MAX_GAP_MS` | 2_700_000 | maximum quiet window (45 min) |
| `SOAK_SUMMARY_INTERVAL_MS` | 300_000 | summary line cadence (5 min) |
| `SOAK_DISABLE_SPIKES` | "" | `'1'` disables spike mode entirely |

## Verified

Fast-cycle smoke (300ms base / 100ms spike / 2-3s spikes every 2-4s):
- `soak.spike.start` / `soak.spike.end` events fire on schedule
- Inside spike: 22 ticks → 303 events; outside spike: 11 ticks → 60 events
- Per-scenario rollup matches expected distribution
- Default 60s/5min config also boots clean inside the container with backend healthcheck

## Out of scope

- Operator runbook + verification queries (HOL-41)

Closes [HOL-40](https://yt.brewingcoder.com/issue/HOL-40). Third-of-four subtasks of [HOL-37](https://yt.brewingcoder.com/issue/HOL-37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)