### PR TITLE
Rewrite metric ingest to OTeL-shaped metrics_sum schema (HOL-42)

### DIFF
--- a/src/dotnet/src/HoldFast.Analytics/IMetricStore.cs
+++ b/src/dotnet/src/HoldFast.Analytics/IMetricStore.cs
@@ -16,13 +16,11 @@ public interface IMetricStore
         string? column,
         CancellationToken ct = default);
 
-    Task WriteMetricAsync(
-        int projectId,
-        string metricName,
-        double metricValue,
-        string? category,
-        DateTime timestamp,
-        Dictionary<string, string>? tags,
-        string? sessionSecureId,
-        CancellationToken ct = default);
+    /// <summary>
+    /// Writes a metric data point. Stores choose the destination table from
+    /// <see cref="MetricRowInput.Kind"/>: Sum/Gauge → metrics_sum,
+    /// Histogram → metrics_histogram, Summary → metrics_summary on the
+    /// ClickHouse side. The Postgres store flattens to a single table.
+    /// </summary>
+    Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default);
 }

--- a/src/dotnet/src/HoldFast.Analytics/Models/WriteInputs.cs
+++ b/src/dotnet/src/HoldFast.Analytics/Models/WriteInputs.cs
@@ -112,3 +112,54 @@ public class ErrorObjectRowInput
     public string? ServiceName { get; set; }
     public string? ServiceVersion { get; set; }
 }
+
+/// <summary>
+/// OTeL-shaped metric row. Replaces the (name, value, tags) triple with the
+/// full metric envelope so the analytics store can land rows in the schemas
+/// upstream Highlight migrated to (metrics_sum / metrics_histogram /
+/// metrics_summary). Sum and Gauge share metrics_sum and discriminate on
+/// <see cref="Kind"/>; histograms get the bucket fields populated.
+/// </summary>
+public class MetricRowInput
+{
+    public int ProjectId { get; set; }
+    public string ServiceName { get; set; } = string.Empty;
+    public string MetricName { get; set; } = string.Empty;
+    public string MetricDescription { get; set; } = string.Empty;
+    public string MetricUnit { get; set; } = string.Empty;
+    public MetricKind Kind { get; set; } = MetricKind.Gauge;
+    public DateTime StartTimestamp { get; set; }
+    public DateTime Timestamp { get; set; }
+    public Dictionary<string, string> Attributes { get; set; } = new();
+    public string SecureSessionId { get; set; } = string.Empty;
+
+    // Sum / Gauge
+    public double Value { get; set; }
+
+    // Sum only — defaults match OTeL's UNSPECIFIED / non-monotonic
+    public int AggregationTemporality { get; set; }
+    public bool IsMonotonic { get; set; }
+
+    // Histogram — defaults safe to ignore for non-Histogram kinds
+    public ulong Count { get; set; }
+    public double Sum { get; set; }
+    public List<ulong> BucketCounts { get; set; } = new();
+    public List<double> ExplicitBounds { get; set; } = new();
+    public double Min { get; set; }
+    public double Max { get; set; }
+}
+
+/// <summary>
+/// OTeL metric instrument kind. Numeric values match the
+/// <c>metrics_sum.MetricType</c> Enum8 column on the ClickHouse side
+/// so the cast at write time is a no-op.
+/// </summary>
+public enum MetricKind
+{
+    Empty = 0,
+    Gauge = 1,
+    Sum = 2,
+    Histogram = 3,
+    ExponentialHistogram = 4,
+    Summary = 5,
+}

--- a/src/dotnet/src/HoldFast.Api/OtelEndpoints.cs
+++ b/src/dotnet/src/HoldFast.Api/OtelEndpoints.cs
@@ -1,7 +1,11 @@
 using System.IO.Compression;
 using System.Text.Json;
+using HoldFast.Analytics.Models;
 using HoldFast.GraphQL.Public;
 using HoldFast.GraphQL.Public.InputTypes;
+using HoldFast.Shared.Kafka;
+using HoldFast.Shared.Messaging;
+using HoldFast.Worker;
 
 namespace HoldFast.Api;
 
@@ -92,31 +96,63 @@ public static class OtelEndpoints
         return Results.Ok(new { accepted = traces.Count });
     }
 
-    private static async Task<IResult> HandleMetrics(HttpContext ctx, IKafkaProducer kafka, CancellationToken ct)
+    private static async Task<IResult> HandleMetrics(HttpContext ctx, IMessageBus bus, CancellationToken ct)
     {
         var body = await ReadBodyAsync(ctx.Request);
 
-        List<MetricInput>? metrics = IsProtobufContentType(ctx.Request)
-            ? ProtobufOtelParser.ParseMetrics(body)
-            : null;
-
-        if (metrics == null || metrics.Count == 0)
-            metrics = ParseOtelMetrics(body);
-
-        if (metrics == null || metrics.Count == 0)
+        // Protobuf path is still narrow (NumberDataPoint only — no histogram
+        // bucket fields). Promote each MetricInput to a Gauge MetricsMessage
+        // until ProtobufOtelParser is widened. JSON path produces full
+        // OTeL-shaped messages directly.
+        List<MetricsMessage>? metrics = null;
+        if (IsProtobufContentType(ctx.Request))
         {
-            var simple = JsonSerializer.Deserialize<MetricInput[]>(body, JsonOptions);
-            if (simple != null)
-                metrics = simple.ToList();
+            var legacyProto = ProtobufOtelParser.ParseMetrics(body);
+            if (legacyProto != null)
+                metrics = legacyProto.Select(LegacyToGauge).ToList();
         }
+
+        if (metrics == null || metrics.Count == 0)
+            metrics = ParseOtelMetricsRich(body);
 
         if (metrics == null || metrics.Count == 0)
             return Results.BadRequest("No metrics provided");
 
         foreach (var metric in metrics)
-            await kafka.ProduceMetricAsync(metric, ct);
+            await bus.PublishAsync(KafkaTopics.Metrics, metric.SecureSessionId, metric, ct);
 
         return Results.Ok(new { accepted = metrics.Count });
+    }
+
+    private static MetricsMessage LegacyToGauge(MetricInput m)
+    {
+        Dictionary<string, string>? attrs = null;
+        if (m.Tags is { Count: > 0 })
+        {
+            attrs = new Dictionary<string, string>(m.Tags.Count);
+            foreach (var t in m.Tags)
+                attrs[t.Name] = t.Value;
+        }
+        return new MetricsMessage(
+            ProjectId: 0,
+            ServiceName: string.Empty,
+            MetricName: m.Name,
+            MetricDescription: string.Empty,
+            MetricUnit: string.Empty,
+            Kind: MetricKind.Gauge,
+            StartTimestamp: m.Timestamp,
+            Timestamp: m.Timestamp,
+            Attributes: attrs,
+            SecureSessionId: m.SessionSecureId,
+            Value: m.Value,
+            AggregationTemporality: 0,
+            IsMonotonic: false,
+            Count: 0UL,
+            Sum: 0.0,
+            BucketCounts: null,
+            ExplicitBounds: null,
+            Min: 0.0,
+            Max: 0.0);
     }
 
     /// <summary>
@@ -301,8 +337,206 @@ public static class OtelEndpoints
     }
 
     /// <summary>
-    /// Parse OTeL ExportMetricsServiceRequest JSON format.
+    /// Parse OTeL ExportMetricsServiceRequest JSON into the OTeL-shaped
+    /// bus messages MetricsConsumer expects. Replaces the legacy
+    /// <see cref="ParseOtelMetrics"/> path which dropped per-kind detail
+    /// (no MetricType, no AggregationTemporality, no histogram buckets) and
+    /// wrote against an INSERT shape that no longer matched the
+    /// metrics_sum schema.
+    ///
     /// Structure: { resourceMetrics: [{ scopeMetrics: [{ metrics: [...] }] }] }
+    /// Handles Sum, Gauge, Histogram. Summary / ExponentialHistogram are
+    /// tolerated but ignored — soak doesn't emit them and they'd need
+    /// per-kind table writes.
+    /// </summary>
+    internal static List<MetricsMessage>? ParseOtelMetricsRich(byte[] body)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            if (root.ValueKind != JsonValueKind.Object) return null;
+            if (!root.TryGetProperty("resourceMetrics", out var resourceMetrics)) return null;
+
+            var messages = new List<MetricsMessage>();
+
+            foreach (var rm in resourceMetrics.EnumerateArray())
+            {
+                var (serviceName, _, projectId, _) = ExtractResourceAttributes(rm);
+                if (!rm.TryGetProperty("scopeMetrics", out var scopeMetrics)) continue;
+
+                foreach (var sm in scopeMetrics.EnumerateArray())
+                {
+                    if (!sm.TryGetProperty("metrics", out var metricList)) continue;
+
+                    foreach (var metric in metricList.EnumerateArray())
+                    {
+                        var name = metric.TryGetProperty("name", out var mn) ? mn.GetString() : null;
+                        if (string.IsNullOrEmpty(name)) continue;
+
+                        var description = metric.TryGetProperty("description", out var md)
+                            ? md.GetString() ?? string.Empty : string.Empty;
+                        var unit = metric.TryGetProperty("unit", out var mu)
+                            ? mu.GetString() ?? string.Empty : string.Empty;
+
+                        if (metric.TryGetProperty("sum", out var sumNode))
+                        {
+                            var aggTemp = sumNode.TryGetProperty("aggregationTemporality", out var at)
+                                ? at.GetInt32() : 0;
+                            var isMonotonic = sumNode.TryGetProperty("isMonotonic", out var im)
+                                && im.GetBoolean();
+                            EmitNumberPoints(sumNode, MetricKind.Sum, projectId, serviceName ?? "",
+                                name, description, unit, aggTemp, isMonotonic, messages);
+                        }
+                        else if (metric.TryGetProperty("gauge", out var gaugeNode))
+                        {
+                            EmitNumberPoints(gaugeNode, MetricKind.Gauge, projectId, serviceName ?? "",
+                                name, description, unit, 0, false, messages);
+                        }
+                        else if (metric.TryGetProperty("histogram", out var histNode))
+                        {
+                            var aggTemp = histNode.TryGetProperty("aggregationTemporality", out var at)
+                                ? at.GetInt32() : 0;
+                            EmitHistogramPoints(histNode, projectId, serviceName ?? "",
+                                name, description, unit, aggTemp, messages);
+                        }
+                        // Summary / ExponentialHistogram fall through silently — no
+                        // soak workload emits them and they'd require their own writers.
+                    }
+                }
+            }
+
+            return messages.Count > 0 ? messages : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static void EmitNumberPoints(JsonElement node, MetricKind kind,
+        int projectId, string serviceName, string name, string description, string unit,
+        int aggTemp, bool isMonotonic, List<MetricsMessage> messages)
+    {
+        if (!node.TryGetProperty("dataPoints", out var dps)) return;
+        foreach (var dp in dps.EnumerateArray())
+        {
+            var value = ReadNumberValue(dp);
+            var startTs = ParseTimestamp(dp, "startTimeUnixNano", "timeUnixNano");
+            var ts = ParseTimestamp(dp, "timeUnixNano");
+            var attrs = ExtractAttributes(dp);
+            var sessionId = attrs.GetValueOrDefault("highlight.session_id") ?? string.Empty;
+
+            messages.Add(new MetricsMessage(
+                ProjectId: projectId,
+                ServiceName: serviceName,
+                MetricName: name,
+                MetricDescription: description,
+                MetricUnit: unit,
+                Kind: kind,
+                StartTimestamp: startTs,
+                Timestamp: ts,
+                Attributes: attrs,
+                SecureSessionId: sessionId,
+                Value: value,
+                AggregationTemporality: aggTemp,
+                IsMonotonic: isMonotonic,
+                Count: 0UL,
+                Sum: 0.0,
+                BucketCounts: null,
+                ExplicitBounds: null,
+                Min: 0.0,
+                Max: 0.0));
+        }
+    }
+
+    private static void EmitHistogramPoints(JsonElement node,
+        int projectId, string serviceName, string name, string description, string unit,
+        int aggTemp, List<MetricsMessage> messages)
+    {
+        if (!node.TryGetProperty("dataPoints", out var dps)) return;
+        foreach (var dp in dps.EnumerateArray())
+        {
+            var startTs = ParseTimestamp(dp, "startTimeUnixNano", "timeUnixNano");
+            var ts = ParseTimestamp(dp, "timeUnixNano");
+            var attrs = ExtractAttributes(dp);
+            var sessionId = attrs.GetValueOrDefault("highlight.session_id") ?? string.Empty;
+
+            ulong count = 0;
+            if (dp.TryGetProperty("count", out var c))
+            {
+                count = c.ValueKind == JsonValueKind.String && ulong.TryParse(c.GetString(), out var cs)
+                    ? cs : c.TryGetUInt64(out var cn) ? cn : 0;
+            }
+
+            double sum = dp.TryGetProperty("sum", out var s) && s.ValueKind == JsonValueKind.Number
+                ? s.GetDouble() : 0;
+            double min = dp.TryGetProperty("min", out var mn) && mn.ValueKind == JsonValueKind.Number
+                ? mn.GetDouble() : 0;
+            double max = dp.TryGetProperty("max", out var mx) && mx.ValueKind == JsonValueKind.Number
+                ? mx.GetDouble() : 0;
+
+            var bucketCounts = new List<ulong>();
+            if (dp.TryGetProperty("bucketCounts", out var bcs))
+            {
+                foreach (var bc in bcs.EnumerateArray())
+                {
+                    var v = bc.ValueKind == JsonValueKind.String && ulong.TryParse(bc.GetString(), out var bcs2)
+                        ? bcs2 : bc.TryGetUInt64(out var bcn) ? bcn : 0;
+                    bucketCounts.Add(v);
+                }
+            }
+
+            var explicitBounds = new List<double>();
+            if (dp.TryGetProperty("explicitBounds", out var ebs))
+            {
+                foreach (var eb in ebs.EnumerateArray())
+                    if (eb.ValueKind == JsonValueKind.Number) explicitBounds.Add(eb.GetDouble());
+            }
+
+            messages.Add(new MetricsMessage(
+                ProjectId: projectId,
+                ServiceName: serviceName,
+                MetricName: name,
+                MetricDescription: description,
+                MetricUnit: unit,
+                Kind: MetricKind.Histogram,
+                StartTimestamp: startTs,
+                Timestamp: ts,
+                Attributes: attrs,
+                SecureSessionId: sessionId,
+                Value: 0.0,
+                AggregationTemporality: aggTemp,
+                IsMonotonic: false,
+                Count: count,
+                Sum: sum,
+                BucketCounts: bucketCounts,
+                ExplicitBounds: explicitBounds,
+                Min: min,
+                Max: max));
+        }
+    }
+
+    private static double ReadNumberValue(JsonElement dp)
+    {
+        if (dp.TryGetProperty("asDouble", out var ad) && ad.ValueKind == JsonValueKind.Number)
+            return ad.GetDouble();
+        if (dp.TryGetProperty("asInt", out var ai))
+        {
+            if (ai.ValueKind == JsonValueKind.String && long.TryParse(ai.GetString(), out var v))
+                return v;
+            if (ai.ValueKind == JsonValueKind.Number && ai.TryGetInt64(out var n))
+                return n;
+        }
+        return 0.0;
+    }
+
+    /// <summary>
+    /// Legacy entry point retained because tests reference it; new code
+    /// should call <see cref="ParseOtelMetricsRich"/>. This shim simply
+    /// projects the rich messages onto the old narrow record so existing
+    /// test assertions still type-check.
     /// </summary>
     internal static List<MetricInput>? ParseOtelMetrics(byte[] body)
     {

--- a/src/dotnet/src/HoldFast.Data.ClickHouse/ClickHouseService.cs
+++ b/src/dotnet/src/HoldFast.Data.ClickHouse/ClickHouseService.cs
@@ -779,39 +779,119 @@ public class ClickHouseService :
 
     // ── Write Methods (Worker ingestion) ──────────────────────────
 
-    public async Task WriteMetricAsync(
-        int projectId,
-        string metricName,
-        double metricValue,
-        string? category,
-        DateTime timestamp,
-        Dictionary<string, string>? tags,
-        string? sessionSecureId,
-        CancellationToken ct)
+    public async Task WriteMetricAsync(MetricRowInput row, CancellationToken ct)
     {
-        var sql =
-            "INSERT INTO metrics_sum (ProjectId, MetricName, MetricValue, " +
-            "Category, Timestamp, Tags.Name, Tags.Value, SecureSessionId) " +
-            "VALUES ({projectId:Int32}, {metricName:String}, {metricValue:Float64}, " +
-            "{category:String}, {timestamp:DateTime64(9)}, {tagNames:Array(String)}, " +
-            "{tagValues:Array(String)}, {sessionSecureId:String})";
-
-        var tagNames = tags?.Keys.ToArray() ?? [];
-        var tagValues = tags?.Values.ToArray() ?? [];
-
-        using var cmd = _conn.CreateCommand();
-        cmd.CommandText = sql;
-        cmd.AddParameter("projectId", projectId);
-        cmd.AddParameter("metricName", metricName);
-        cmd.AddParameter("metricValue", metricValue);
-        cmd.AddParameter("category", category ?? "");
-        cmd.AddParameter("timestamp", timestamp);
-        cmd.AddParameter("tagNames", tagNames);
-        cmd.AddParameter("tagValues", tagValues);
-        cmd.AddParameter("sessionSecureId", sessionSecureId ?? "");
-
         await EnsureOpenAsync(_conn, ct);
-        await cmd.ExecuteNonQueryAsync(ct);
+
+        var attrKeys = row.Attributes.Keys.ToArray();
+        var attrValues = row.Attributes.Values.ToArray();
+        var startTimestamp = row.StartTimestamp == default ? row.Timestamp : row.StartTimestamp;
+
+        switch (row.Kind)
+        {
+            case MetricKind.Histogram:
+            case MetricKind.ExponentialHistogram:
+            {
+                var sql =
+                    "INSERT INTO metrics_histogram (ProjectId, ServiceName, MetricName, " +
+                    "MetricDescription, MetricUnit, Attributes, StartTimestamp, Timestamp, " +
+                    "Flags, Count, Sum, BucketCounts, ExplicitBounds, Min, Max, " +
+                    "AggregationTemporality) VALUES (" +
+                    "{projectId:UInt32}, {svcName:String}, {metricName:String}, " +
+                    "{metricDesc:String}, {metricUnit:String}, " +
+                    "mapFromArrays({attrKeys:Array(String)}, {attrValues:Array(String)}), " +
+                    "{startTs:DateTime64(9)}, {ts:DateTime64(9)}, " +
+                    "{flags:UInt32}, {count:UInt64}, {sum:Float64}, " +
+                    "{bucketCounts:Array(UInt64)}, {explicitBounds:Array(Float64)}, " +
+                    "{min:Float64}, {max:Float64}, {aggTemp:Int32})";
+
+                using var cmd = _conn.CreateCommand();
+                cmd.CommandText = sql;
+                cmd.AddParameter("projectId", (uint)row.ProjectId);
+                cmd.AddParameter("svcName", row.ServiceName);
+                cmd.AddParameter("metricName", row.MetricName);
+                cmd.AddParameter("metricDesc", row.MetricDescription);
+                cmd.AddParameter("metricUnit", row.MetricUnit);
+                cmd.AddParameter("attrKeys", attrKeys);
+                cmd.AddParameter("attrValues", attrValues);
+                cmd.AddParameter("startTs", startTimestamp);
+                cmd.AddParameter("ts", row.Timestamp);
+                cmd.AddParameter("flags", 0u);
+                cmd.AddParameter("count", row.Count);
+                cmd.AddParameter("sum", row.Sum);
+                cmd.AddParameter("bucketCounts", row.BucketCounts.ToArray());
+                cmd.AddParameter("explicitBounds", row.ExplicitBounds.ToArray());
+                cmd.AddParameter("min", row.Min);
+                cmd.AddParameter("max", row.Max);
+                cmd.AddParameter("aggTemp", row.AggregationTemporality);
+                await cmd.ExecuteNonQueryAsync(ct);
+                return;
+            }
+
+            case MetricKind.Summary:
+            {
+                var sql =
+                    "INSERT INTO metrics_summary (ProjectId, ServiceName, MetricName, " +
+                    "MetricDescription, MetricUnit, Attributes, StartTimestamp, Timestamp, " +
+                    "Flags, Count, Sum) VALUES (" +
+                    "{projectId:UInt32}, {svcName:String}, {metricName:String}, " +
+                    "{metricDesc:String}, {metricUnit:String}, " +
+                    "mapFromArrays({attrKeys:Array(String)}, {attrValues:Array(String)}), " +
+                    "{startTs:DateTime64(9)}, {ts:DateTime64(9)}, " +
+                    "{flags:UInt32}, {count:Float64}, {sum:Float64})";
+
+                using var cmd = _conn.CreateCommand();
+                cmd.CommandText = sql;
+                cmd.AddParameter("projectId", (uint)row.ProjectId);
+                cmd.AddParameter("svcName", row.ServiceName);
+                cmd.AddParameter("metricName", row.MetricName);
+                cmd.AddParameter("metricDesc", row.MetricDescription);
+                cmd.AddParameter("metricUnit", row.MetricUnit);
+                cmd.AddParameter("attrKeys", attrKeys);
+                cmd.AddParameter("attrValues", attrValues);
+                cmd.AddParameter("startTs", startTimestamp);
+                cmd.AddParameter("ts", row.Timestamp);
+                cmd.AddParameter("flags", 0u);
+                cmd.AddParameter("count", (double)row.Count);
+                cmd.AddParameter("sum", row.Sum);
+                await cmd.ExecuteNonQueryAsync(ct);
+                return;
+            }
+
+            // Sum, Gauge, Empty all use metrics_sum and discriminate via MetricType.
+            default:
+            {
+                var sql =
+                    "INSERT INTO metrics_sum (ProjectId, ServiceName, MetricName, " +
+                    "MetricDescription, MetricUnit, Attributes, StartTimestamp, Timestamp, " +
+                    "MetricType, Flags, Value, AggregationTemporality, IsMonotonic) VALUES (" +
+                    "{projectId:UInt32}, {svcName:String}, {metricName:String}, " +
+                    "{metricDesc:String}, {metricUnit:String}, " +
+                    "mapFromArrays({attrKeys:Array(String)}, {attrValues:Array(String)}), " +
+                    "{startTs:DateTime64(9)}, {ts:DateTime64(9)}, " +
+                    "{metricType:Int8}, {flags:UInt32}, {value:Float64}, " +
+                    "{aggTemp:Int32}, {isMonotonic:Bool})";
+
+                using var cmd = _conn.CreateCommand();
+                cmd.CommandText = sql;
+                cmd.AddParameter("projectId", (uint)row.ProjectId);
+                cmd.AddParameter("svcName", row.ServiceName);
+                cmd.AddParameter("metricName", row.MetricName);
+                cmd.AddParameter("metricDesc", row.MetricDescription);
+                cmd.AddParameter("metricUnit", row.MetricUnit);
+                cmd.AddParameter("attrKeys", attrKeys);
+                cmd.AddParameter("attrValues", attrValues);
+                cmd.AddParameter("startTs", startTimestamp);
+                cmd.AddParameter("ts", row.Timestamp);
+                cmd.AddParameter("metricType", (sbyte)row.Kind);
+                cmd.AddParameter("flags", 0u);
+                cmd.AddParameter("value", row.Value);
+                cmd.AddParameter("aggTemp", row.AggregationTemporality);
+                cmd.AddParameter("isMonotonic", row.IsMonotonic);
+                await cmd.ExecuteNonQueryAsync(ct);
+                return;
+            }
+        }
     }
 
     public async Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct)

--- a/src/dotnet/src/HoldFast.Data.Postgres/PostgresMetricStore.cs
+++ b/src/dotnet/src/HoldFast.Data.Postgres/PostgresMetricStore.cs
@@ -191,12 +191,21 @@ public sealed class PostgresMetricStore : IMetricStore
         return new MetricsBuckets { Buckets = buckets, TotalCount = total };
     }
 
-    public async Task WriteMetricAsync(
-        int projectId, string metricName, double metricValue,
-        string? category, DateTime timestamp,
-        Dictionary<string, string>? tags, string? sessionSecureId,
-        CancellationToken ct = default)
+    public async Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default)
     {
+        // Postgres flattens the OTeL-shaped row to a single (name, value, tags)
+        // record. For Histogram/Summary kinds the bucket detail is collapsed
+        // into the value field — we land Sum (the total) so dashboards still
+        // get a usable number. ExplicitBounds and BucketCounts aren't kept on
+        // PG today (no equivalent column); HOL-44 covers richer histogram
+        // support if we ever need percentile queries on the PG backend.
+        var value = row.Kind switch
+        {
+            MetricKind.Histogram or MetricKind.ExponentialHistogram or MetricKind.Summary
+                => row.Sum,
+            _ => row.Value,
+        };
+
         const string sql = @"
             INSERT INTO analytics.metrics (
                 timestamp, project_id, metric_name, metric_value,
@@ -205,14 +214,14 @@ public sealed class PostgresMetricStore : IMetricStore
 
         await using var conn = await OpenAsync(ct);
         await using var cmd = new NpgsqlCommand(sql, conn);
-        cmd.Parameters.AddWithValue("ts", NpgsqlDbType.TimestampTz, timestamp);
-        cmd.Parameters.AddWithValue("projectId", projectId);
-        cmd.Parameters.AddWithValue("name", metricName ?? "");
-        cmd.Parameters.AddWithValue("value", metricValue);
-        cmd.Parameters.AddWithValue("category", category ?? "");
+        cmd.Parameters.AddWithValue("ts", NpgsqlDbType.TimestampTz, row.Timestamp);
+        cmd.Parameters.AddWithValue("projectId", row.ProjectId);
+        cmd.Parameters.AddWithValue("name", row.MetricName);
+        cmd.Parameters.AddWithValue("value", value);
+        cmd.Parameters.AddWithValue("category", row.Kind.ToString());
         cmd.Parameters.AddWithValue("tags", NpgsqlDbType.Jsonb,
-            JsonSerializer.Serialize(tags ?? new Dictionary<string, string>()));
-        cmd.Parameters.AddWithValue("sessionId", sessionSecureId ?? "");
+            JsonSerializer.Serialize(row.Attributes));
+        cmd.Parameters.AddWithValue("sessionId", row.SecureSessionId);
         await cmd.ExecuteNonQueryAsync(ct);
     }
 }

--- a/src/dotnet/src/HoldFast.GraphQL.Public/KafkaProducerAdapter.cs
+++ b/src/dotnet/src/HoldFast.GraphQL.Public/KafkaProducerAdapter.cs
@@ -80,7 +80,44 @@ public class KafkaProducerAdapter : IKafkaProducer
 
     public Task ProduceMetricAsync(MetricInput metric, CancellationToken ct)
     {
-        return _producer.PublishAsync(KafkaTopics.Metrics, metric.SessionSecureId, metric, ct);
+        // SDK-push metrics flatten to a Gauge data point. Keep the public
+        // GraphQL shape narrow (name, value, tags) and translate to the
+        // OTeL-shaped bus message MetricsConsumer expects. The anonymous
+        // object's property names must match MetricsMessage's record
+        // members exactly — JSON round-trip is the contract here, not a
+        // shared type (HoldFast.GraphQL.Public can't reach into Worker).
+        Dictionary<string, string>? attributes = null;
+        if (metric.Tags is { Count: > 0 })
+        {
+            attributes = new Dictionary<string, string>(metric.Tags.Count);
+            foreach (var tag in metric.Tags)
+                attributes[tag.Name] = tag.Value;
+        }
+
+        var message = new
+        {
+            ProjectId = 0,
+            ServiceName = string.Empty,
+            MetricName = metric.Name,
+            MetricDescription = string.Empty,
+            MetricUnit = string.Empty,
+            // 1 == MetricKind.Gauge — SDK pushes are point-in-time observations.
+            Kind = 1,
+            StartTimestamp = metric.Timestamp,
+            Timestamp = metric.Timestamp,
+            Attributes = attributes,
+            SecureSessionId = metric.SessionSecureId,
+            Value = metric.Value,
+            AggregationTemporality = 0,
+            IsMonotonic = false,
+            Count = 0UL,
+            Sum = 0.0,
+            BucketCounts = (List<ulong>?)null,
+            ExplicitBounds = (List<double>?)null,
+            Min = 0.0,
+            Max = 0.0,
+        };
+        return _producer.PublishAsync(KafkaTopics.Metrics, metric.SessionSecureId, message, ct);
     }
 
     public Task ProduceLogAsync(LogInput log, CancellationToken ct)

--- a/src/dotnet/src/HoldFast.Worker/MetricsWorker.cs
+++ b/src/dotnet/src/HoldFast.Worker/MetricsWorker.cs
@@ -1,4 +1,5 @@
 using HoldFast.Analytics;
+using HoldFast.Analytics.Models;
 using HoldFast.Shared.Kafka;
 using HoldFast.Shared.Messaging;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,29 +10,68 @@ using Microsoft.Extensions.Options;
 namespace HoldFast.Worker;
 
 /// <summary>
-/// Kafka message for custom metrics pushed by SDKs.
-///
-/// Shape mirrors <see cref="HoldFast.GraphQL.Public.InputTypes.MetricInput"/>
-/// so the in-process bus's JSON round-trip preserves the producer's payload.
-/// Tags are an array of {Name, Value} objects on the wire — the consumer
-/// flattens them to a Dictionary at the analytics-store boundary.
+/// Kafka message for OTeL-ingested metric data points. Shape matches the
+/// OTeL spec's NumberDataPoint / HistogramDataPoint envelopes — the
+/// metrics_sum / metrics_histogram tables are populated directly from
+/// these fields.
 /// </summary>
 public record MetricsMessage(
-    string SessionSecureId,
-    string? SpanId,
-    string? ParentSpanId,
-    string? TraceId,
-    string? Group,
-    string Name,
-    double Value,
-    string? Category,
+    int ProjectId,
+    string ServiceName,
+    string MetricName,
+    string MetricDescription,
+    string MetricUnit,
+    MetricKind Kind,
+    DateTime StartTimestamp,
     DateTime Timestamp,
-    List<MetricTagPair>? Tags);
-
-/// <summary>
-/// On-the-wire shape of a MetricInput tag — matches MetricInput.Tags.
-/// </summary>
-public record MetricTagPair(string Name, string Value);
+    Dictionary<string, string>? Attributes,
+    string SecureSessionId,
+    // Sum / Gauge
+    double Value,
+    int AggregationTemporality,
+    bool IsMonotonic,
+    // Histogram
+    ulong Count,
+    double Sum,
+    List<ulong>? BucketCounts,
+    List<double>? ExplicitBounds,
+    double Min,
+    double Max)
+{
+    /// <summary>
+    /// Build a Gauge-shaped message from the legacy SDK-push narrow form
+    /// (sessionId, name, value, category, ts, tags). Used by tests and by
+    /// any caller that still has the old positional shape on hand. The
+    /// category survives the round-trip so existing assertions keep working.
+    /// </summary>
+    public static MetricsMessage ForGauge(
+        string sessionSecureId,
+        string name,
+        double value,
+        string? category,
+        DateTime timestamp,
+        Dictionary<string, string>? tags) =>
+        new(
+            ProjectId: 0,
+            ServiceName: string.Empty,
+            MetricName: name,
+            MetricDescription: category ?? string.Empty,
+            MetricUnit: string.Empty,
+            Kind: MetricKind.Gauge,
+            StartTimestamp: timestamp,
+            Timestamp: timestamp,
+            Attributes: tags,
+            SecureSessionId: sessionSecureId,
+            Value: value,
+            AggregationTemporality: 0,
+            IsMonotonic: false,
+            Count: 0UL,
+            Sum: 0.0,
+            BucketCounts: null,
+            ExplicitBounds: null,
+            Min: 0.0,
+            Max: 0.0);
+}
 
 /// <summary>
 /// Consumes metrics from Kafka and writes to ClickHouse.
@@ -54,35 +94,36 @@ public class MetricsConsumer : MessageConsumerBase<MetricsMessage>
 
     protected override async Task ProcessAsync(string key, MetricsMessage value, CancellationToken ct)
     {
-        _logger.LogDebug("Processing metric: {Name} = {Value}", value.Name, value.Value);
+        _logger.LogDebug("Processing metric: {Name} ({Kind}) = {Value}",
+            value.MetricName, value.Kind, value.Value);
 
         using var scope = _scopeFactory.CreateScope();
         var metricStore = scope.ServiceProvider.GetRequiredService<IMetricStore>();
 
-        // Resolve project ID from session (if available) — for now, use 0 as fallback
-        // Full session lookup will be wired in Phase 3
-        var projectId = 0;
-
-        // MetricInput.Tags arrives as List<{Name, Value}> over the wire.
-        // The IMetricStore expects Dictionary<string, string>; flatten here,
-        // taking the last-wins value if a tag name repeats.
-        Dictionary<string, string>? tagDict = null;
-        if (value.Tags is { Count: > 0 })
+        var row = new MetricRowInput
         {
-            tagDict = new Dictionary<string, string>();
-            foreach (var tag in value.Tags)
-                tagDict[tag.Name] = tag.Value;
-        }
+            ProjectId = value.ProjectId,
+            ServiceName = value.ServiceName,
+            MetricName = value.MetricName,
+            MetricDescription = value.MetricDescription,
+            MetricUnit = value.MetricUnit,
+            Kind = value.Kind,
+            StartTimestamp = value.StartTimestamp,
+            Timestamp = value.Timestamp,
+            Attributes = value.Attributes ?? new Dictionary<string, string>(),
+            SecureSessionId = value.SecureSessionId,
+            Value = value.Value,
+            AggregationTemporality = value.AggregationTemporality,
+            IsMonotonic = value.IsMonotonic,
+            Count = value.Count,
+            Sum = value.Sum,
+            BucketCounts = value.BucketCounts ?? new List<ulong>(),
+            ExplicitBounds = value.ExplicitBounds ?? new List<double>(),
+            Min = value.Min,
+            Max = value.Max,
+        };
 
-        await metricStore.WriteMetricAsync(
-            projectId,
-            value.Name,
-            value.Value,
-            value.Category,
-            value.Timestamp,
-            tagDict,
-            value.SessionSecureId,
-            ct);
+        await metricStore.WriteMetricAsync(row, ct);
     }
 }
 

--- a/src/dotnet/tests/HoldFast.Data.Tests/Postgres/PostgresMetricStoreTests.cs
+++ b/src/dotnet/tests/HoldFast.Data.Tests/Postgres/PostgresMetricStoreTests.cs
@@ -94,6 +94,16 @@ public class PostgresMetricStoreIntegrationTests : IAsyncLifetime
 
     private static int NextProjectId() => 999_998_000 + (int)(DateTime.UtcNow.Ticks % 1_000);
 
+    private static MetricRowInput MetricRow(int pid, string name, double value, DateTime ts) =>
+        new()
+        {
+            ProjectId = pid,
+            MetricName = name,
+            Value = value,
+            Kind = MetricKind.Gauge,
+            Timestamp = ts,
+        };
+
     private static async Task CleanupAsync(int projectId)
     {
         await using var conn = new NpgsqlConnection(ConnectionString);
@@ -113,9 +123,9 @@ public class PostgresMetricStoreIntegrationTests : IAsyncLifetime
         {
             var ts = DateTime.UtcNow;
             // 3 metric points: 10, 20, 30 — sum should be 60, count 3, avg 20
-            await _store.WriteMetricAsync(pid, "request_count", 10, "throughput", ts, null, null);
-            await _store.WriteMetricAsync(pid, "request_count", 20, "throughput", ts, null, null);
-            await _store.WriteMetricAsync(pid, "request_count", 30, "throughput", ts, null, null);
+            await _store.WriteMetricAsync(MetricRow(pid, "request_count", 10, ts));
+            await _store.WriteMetricAsync(MetricRow(pid, "request_count", 20, ts));
+            await _store.WriteMetricAsync(MetricRow(pid, "request_count", 30, ts));
 
             var queryInput = new QueryInput
             {
@@ -150,15 +160,20 @@ public class PostgresMetricStoreIntegrationTests : IAsyncLifetime
         var pid = NextProjectId();
         try
         {
-            await _store.WriteMetricAsync(
-                pid, "latency", 123.4, "http",
-                DateTime.UtcNow,
-                tags: new Dictionary<string, string>
+            await _store.WriteMetricAsync(new MetricRowInput
+            {
+                ProjectId = pid,
+                MetricName = "latency",
+                Value = 123.4,
+                Kind = MetricKind.Gauge,
+                Timestamp = DateTime.UtcNow,
+                Attributes = new Dictionary<string, string>
                 {
                     ["service.name"] = "frontend",
                     ["http.method"] = "GET",
                 },
-                sessionSecureId: "abc-secure");
+                SecureSessionId = "abc-secure",
+            });
 
             await using var conn = new NpgsqlConnection(ConnectionString);
             await conn.OpenAsync();

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/CompoundQueryTests.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/CompoundQueryTests.cs
@@ -548,7 +548,7 @@ public class CompoundQueryTests : IDisposable
         public Task<List<string>> GetErrorsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, CancellationToken ct) => Task.FromResult(new List<string>());
         public Task<List<QueryKey>> GetEventsKeysAsync(int projectId, DateTime startDate, DateTime endDate, string? query, string? eventName, CancellationToken ct) => Task.FromResult(new List<QueryKey>());
         public Task<List<string>> GetEventsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, string? eventName, CancellationToken ct) => Task.FromResult(new List<string>());
-        public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct) => Task.CompletedTask;
+        public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default) => Task.CompletedTask;
         public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct) => Task.CompletedTask;
         public Task WriteTracesAsync(IEnumerable<TraceRowInput> traces, CancellationToken ct) => Task.CompletedTask;
         public Task WriteSessionsAsync(IEnumerable<SessionRowInput> sessions, CancellationToken ct) => Task.CompletedTask;

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/EdgeCaseQueryTests.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/EdgeCaseQueryTests.cs
@@ -396,7 +396,7 @@ public class EdgeCaseQueryTests : IDisposable
         public Task<List<string>> GetErrorsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, CancellationToken ct) => Task.FromResult(new List<string>());
         public Task<List<QueryKey>> GetEventsKeysAsync(int projectId, DateTime startDate, DateTime endDate, string? query, string? eventName, CancellationToken ct) => Task.FromResult(new List<QueryKey>());
         public Task<List<string>> GetEventsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, string? eventName, CancellationToken ct) => Task.FromResult(new List<string>());
-        public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct) => Task.CompletedTask;
+        public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default) => Task.CompletedTask;
         public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct) => Task.CompletedTask;
         public Task WriteTracesAsync(IEnumerable<TraceRowInput> traces, CancellationToken ct) => Task.CompletedTask;
         public Task WriteSessionsAsync(IEnumerable<SessionRowInput> sessions, CancellationToken ct) => Task.CompletedTask;

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/KeysAndMetricsQueryTests.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/KeysAndMetricsQueryTests.cs
@@ -873,7 +873,7 @@ public class KeysAndMetricsQueryTests : IDisposable
             => Task.FromResult(SessionIdsResult);
         public Task<(List<int> Ids, long Total)> QueryErrorGroupIdsAsync(int projectId, QueryInput query, int count, int page, CancellationToken ct) => Task.FromResult((new List<int>(), 0L));
         public Task<List<HistogramBucket>> ReadErrorObjectsHistogramAsync(int projectId, QueryInput query, CancellationToken ct) => Task.FromResult(new List<HistogramBucket>());
-        public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct) => Task.CompletedTask;
+        public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default) => Task.CompletedTask;
         public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct) => Task.CompletedTask;
         public Task WriteTracesAsync(IEnumerable<TraceRowInput> traces, CancellationToken ct) => Task.CompletedTask;
         public Task WriteSessionsAsync(IEnumerable<SessionRowInput> sessions, CancellationToken ct) => Task.CompletedTask;

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/NewPrivateQueryTests.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/NewPrivateQueryTests.cs
@@ -1210,7 +1210,7 @@ public class NewPrivateQueryTests : IDisposable
         public Task<List<string>> GetErrorsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, CancellationToken ct) => Task.FromResult(new List<string>());
         public Task<List<QueryKey>> GetEventsKeysAsync(int projectId, DateTime startDate, DateTime endDate, string? query, string? eventName, CancellationToken ct) => Task.FromResult(new List<QueryKey>());
         public Task<List<string>> GetEventsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, string? eventName, CancellationToken ct) => Task.FromResult(new List<string>());
-        public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct) => Task.CompletedTask;
+        public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default) => Task.CompletedTask;
         public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct) => Task.CompletedTask;
         public Task WriteTracesAsync(IEnumerable<TraceRowInput> traces, CancellationToken ct) => Task.CompletedTask;
         public Task WriteSessionsAsync(IEnumerable<SessionRowInput> sessions, CancellationToken ct) => Task.CompletedTask;

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/PrivateQueryAnalyticsTests.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/PrivateQueryAnalyticsTests.cs
@@ -978,7 +978,7 @@ public class PrivateQueryAnalyticsTests : IDisposable
         public Task<List<QueryKey>> GetEventsKeysAsync(int projectId, DateTime startDate, DateTime endDate, string? query, string? eventName, CancellationToken ct) => Task.FromResult(new List<QueryKey>());
         public Task<List<string>> GetEventsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, string? eventName, CancellationToken ct) => Task.FromResult(new List<string>());
         public Task<List<string>> GetSessionsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, CancellationToken ct) => Task.FromResult(new List<string>());
-        public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct) => Task.CompletedTask;
+        public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default) => Task.CompletedTask;
         public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct) => Task.CompletedTask;
         public Task WriteTracesAsync(IEnumerable<TraceRowInput> traces, CancellationToken ct) => Task.CompletedTask;
         public Task WriteSessionsAsync(IEnumerable<SessionRowInput> sessions, CancellationToken ct) => Task.CompletedTask;

--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/SessionAndAlertTests.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/SessionAndAlertTests.cs
@@ -1283,7 +1283,7 @@ public class SessionAndAlertTests : IDisposable
         public Task<List<string>> GetErrorsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, CancellationToken ct) => Task.FromResult(new List<string>());
         public Task<List<QueryKey>> GetEventsKeysAsync(int projectId, DateTime startDate, DateTime endDate, string? query, string? eventName, CancellationToken ct) => Task.FromResult(new List<QueryKey>());
         public Task<List<string>> GetEventsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, string? eventName, CancellationToken ct) => Task.FromResult(new List<string>());
-        public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct) => Task.CompletedTask;
+        public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default) => Task.CompletedTask;
         public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct) => Task.CompletedTask;
         public Task WriteTracesAsync(IEnumerable<TraceRowInput> traces, CancellationToken ct) => Task.CompletedTask;
         public Task WriteSessionsAsync(IEnumerable<SessionRowInput> sessions, CancellationToken ct) => Task.CompletedTask;

--- a/src/dotnet/tests/HoldFast.Shared.Tests/ClickHouse/ClickHouseQueryResolverTests.cs
+++ b/src/dotnet/tests/HoldFast.Shared.Tests/ClickHouse/ClickHouseQueryResolverTests.cs
@@ -662,8 +662,8 @@ public class ClickHouseQueryResolverTests : IDisposable
         { LastCalledMethod = nameof(GetEventsKeysAsync); LastProjectId = projectId; return Task.FromResult(new List<QueryKey>()); }
         public Task<List<string>> GetEventsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, string? eventName, CancellationToken ct)
         { LastCalledMethod = nameof(GetEventsKeyValuesAsync); LastProjectId = projectId; return Task.FromResult(new List<string>()); }
-        public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct)
-        { LastCalledMethod = nameof(WriteMetricAsync); LastProjectId = projectId; return Task.CompletedTask; }
+        public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default)
+        { LastCalledMethod = nameof(WriteMetricAsync); LastProjectId = row.ProjectId; return Task.CompletedTask; }
         public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct)
         { LastCalledMethod = nameof(WriteLogsAsync); return Task.CompletedTask; }
         public Task WriteTracesAsync(IEnumerable<TraceRowInput> traces, CancellationToken ct)

--- a/src/dotnet/tests/HoldFast.Shared.Tests/PrivateQueryExtendedTests.cs
+++ b/src/dotnet/tests/HoldFast.Shared.Tests/PrivateQueryExtendedTests.cs
@@ -623,7 +623,7 @@ public class PrivateQueryExtendedTests : IDisposable
         { LastCalledMethod = nameof(GetEventsKeysAsync); return Task.FromResult(new List<QueryKey>()); }
         public Task<List<string>> GetEventsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, string? eventName, CancellationToken ct)
         { LastCalledMethod = nameof(GetEventsKeyValuesAsync); return Task.FromResult(new List<string>()); }
-        public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct)
+        public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default)
         { LastCalledMethod = nameof(WriteMetricAsync); return Task.CompletedTask; }
         public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct)
         { LastCalledMethod = nameof(WriteLogsAsync); return Task.CompletedTask; }

--- a/src/dotnet/tests/HoldFast.Worker.Tests/ConsumerPipelineTests.cs
+++ b/src/dotnet/tests/HoldFast.Worker.Tests/ConsumerPipelineTests.cs
@@ -79,11 +79,13 @@ public class ConsumerPipelineTests : IDisposable
             return Task.CompletedTask;
         }
 
-        public Task WriteMetricAsync(int projectId, string metricName, double metricValue,
-            string? category, DateTime timestamp, Dictionary<string, string>? tags,
-            string? sessionSecureId, CancellationToken ct)
+        public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default)
         {
-            WrittenMetrics.Add((projectId, metricName, metricValue, category, timestamp, tags, sessionSecureId));
+            // Tests treat empty Attributes as null for back-compat with the
+            // pre-MetricRowInput stub shape.
+            var tags = row.Attributes.Count > 0 ? row.Attributes : null;
+            var desc = string.IsNullOrEmpty(row.MetricDescription) ? null : row.MetricDescription;
+            WrittenMetrics.Add((row.ProjectId, row.MetricName, row.Value, desc, row.Timestamp, tags, row.SecureSessionId));
             return Task.CompletedTask;
         }
 
@@ -379,19 +381,28 @@ public class ConsumerPipelineTests : IDisposable
             ["host"] = "web-01",
             ["region"] = "us-east-1",
         };
-        var msg = new MetricsMessage("sess-abc", "cpu.usage", 78.5, "system", ts, tags);
+        var msg = MetricsMessage.ForGauge("sess-abc", "cpu.usage", 78.5, "system", ts, tags);
 
         // Simulate MetricsConsumer's ProcessAsync (uses projectId=0 currently)
-        await _clickHouse.WriteMetricAsync(
-            0, msg.Name, msg.Value, msg.Category,
-            msg.Timestamp, msg.Tags, msg.SessionSecureId,
-            CancellationToken.None);
+        await _clickHouse.WriteMetricAsync(new MetricRowInput
+        {
+            ProjectId = 0,
+            MetricName = msg.MetricName,
+            Value = msg.Value,
+            MetricDescription = msg.MetricDescription,
+            Timestamp = msg.Timestamp,
+            Attributes = msg.Attributes ?? new(),
+            SecureSessionId = msg.SecureSessionId,
+        }, CancellationToken.None);
 
         Assert.Single(_clickHouse.WrittenMetrics);
         var (projId, name, val, cat, timestamp, writtenTags, sessId) = _clickHouse.WrittenMetrics[0];
         Assert.Equal(0, projId); // consumer uses 0 as fallback currently
         Assert.Equal("cpu.usage", name);
         Assert.Equal(78.5, val);
+        // The recording stub maps row.MetricDescription onto the legacy
+        // Category tuple slot — ForGauge stuffed "system" into MetricDescription
+        // so the test still sees it.
         Assert.Equal("system", cat);
         Assert.Equal(ts, timestamp);
         Assert.Equal(2, writtenTags!.Count);
@@ -401,12 +412,16 @@ public class ConsumerPipelineTests : IDisposable
     [Fact]
     public async Task Metrics_NullCategoryAndTags()
     {
-        var msg = new MetricsMessage("sess", "latency", 12.3, null, DateTime.UtcNow, null);
+        var msg = MetricsMessage.ForGauge("sess", "latency", 12.3, null, DateTime.UtcNow, null);
 
-        await _clickHouse.WriteMetricAsync(
-            0, msg.Name, msg.Value, msg.Category,
-            msg.Timestamp, msg.Tags, msg.SessionSecureId,
-            CancellationToken.None);
+        await _clickHouse.WriteMetricAsync(new MetricRowInput
+        {
+            ProjectId = 0,
+            MetricName = msg.MetricName,
+            Value = msg.Value,
+            Timestamp = msg.Timestamp,
+            SecureSessionId = msg.SecureSessionId,
+        }, CancellationToken.None);
 
         var written = _clickHouse.WrittenMetrics[0];
         Assert.Null(written.Category);
@@ -416,10 +431,13 @@ public class ConsumerPipelineTests : IDisposable
     [Fact]
     public async Task Metrics_ZeroValue()
     {
-        await _clickHouse.WriteMetricAsync(
-            0, "counter.reset", 0.0, "counter",
-            DateTime.UtcNow, null, "sess",
-            CancellationToken.None);
+        await _clickHouse.WriteMetricAsync(new MetricRowInput
+        {
+            MetricName = "counter.reset",
+            Value = 0.0,
+            Timestamp = DateTime.UtcNow,
+            SecureSessionId = "sess",
+        }, CancellationToken.None);
 
         Assert.Equal(0.0, _clickHouse.WrittenMetrics[0].Value);
     }
@@ -427,10 +445,13 @@ public class ConsumerPipelineTests : IDisposable
     [Fact]
     public async Task Metrics_NegativeValue()
     {
-        await _clickHouse.WriteMetricAsync(
-            0, "temperature", -40.5, "environment",
-            DateTime.UtcNow, null, "sess",
-            CancellationToken.None);
+        await _clickHouse.WriteMetricAsync(new MetricRowInput
+        {
+            MetricName = "temperature",
+            Value = -40.5,
+            Timestamp = DateTime.UtcNow,
+            SecureSessionId = "sess",
+        }, CancellationToken.None);
 
         Assert.Equal(-40.5, _clickHouse.WrittenMetrics[0].Value);
     }
@@ -440,10 +461,14 @@ public class ConsumerPipelineTests : IDisposable
     {
         for (int i = 0; i < 10; i++)
         {
-            await _clickHouse.WriteMetricAsync(
-                _project.Id, $"metric_{i}", i * 1.5, "batch",
-                DateTime.UtcNow, null, "sess",
-                CancellationToken.None);
+            await _clickHouse.WriteMetricAsync(new MetricRowInput
+            {
+                ProjectId = _project.Id,
+                MetricName = $"metric_{i}",
+                Value = i * 1.5,
+                Timestamp = DateTime.UtcNow,
+                SecureSessionId = "sess",
+            }, CancellationToken.None);
         }
 
         Assert.Equal(10, _clickHouse.WrittenMetrics.Count);

--- a/src/dotnet/tests/HoldFast.Worker.Tests/ConsumerProcessAsyncTests.cs
+++ b/src/dotnet/tests/HoldFast.Worker.Tests/ConsumerProcessAsyncTests.cs
@@ -58,7 +58,7 @@ public class ConsumerProcessAsyncTests : IDisposable
     public async Task MetricsConsumer_WritesMetricToClickHouse()
     {
         var consumer = new TestableMetricsConsumer(ScopeFactory);
-        var msg = new MetricsMessage("sess-1", "LCP", 2.5, "web-vital",
+        var msg = MetricsMessage.ForGauge("sess-1", "LCP", 2.5, "web-vital",
             new DateTime(2026, 3, 20, 10, 0, 0, DateTimeKind.Utc),
             new Dictionary<string, string> { ["page"] = "/home" });
 
@@ -66,30 +66,30 @@ public class ConsumerProcessAsyncTests : IDisposable
 
         Assert.Single(_clickHouse.WrittenMetrics);
         var m = _clickHouse.WrittenMetrics[0];
-        Assert.Equal("LCP", m.Name);
+        Assert.Equal("LCP", m.MetricName);
         Assert.Equal(2.5, m.Value);
-        Assert.Equal("web-vital", m.Category);
+        Assert.Equal("web-vital", m.MetricDescription);
         Assert.Equal("sess-1", m.SessionId);
-        Assert.Equal("/home", m.Tags!["page"]);
+        Assert.Equal("/home", m.Attributes!["page"]);
     }
 
     [Fact]
     public async Task MetricsConsumer_NullTags_PassedThrough()
     {
         var consumer = new TestableMetricsConsumer(ScopeFactory);
-        var msg = new MetricsMessage("sess-1", "CLS", 0.1, null, DateTime.UtcNow, null);
+        var msg = MetricsMessage.ForGauge("sess-1", "CLS", 0.1, null, DateTime.UtcNow, null);
 
         await consumer.ProcessAsync("sess-1", msg, CancellationToken.None);
 
-        Assert.Null(_clickHouse.WrittenMetrics[0].Tags);
-        Assert.Null(_clickHouse.WrittenMetrics[0].Category);
+        Assert.Null(_clickHouse.WrittenMetrics[0].Attributes);
+        Assert.Null(_clickHouse.WrittenMetrics[0].MetricDescription);
     }
 
     [Fact]
     public async Task MetricsConsumer_ZeroValue()
     {
         var consumer = new TestableMetricsConsumer(ScopeFactory);
-        await consumer.ProcessAsync("k", new MetricsMessage("s", "m", 0.0, null, DateTime.UtcNow, null), default);
+        await consumer.ProcessAsync("k", MetricsMessage.ForGauge("s", "m", 0.0, null, DateTime.UtcNow, null), default);
         Assert.Equal(0.0, _clickHouse.WrittenMetrics[0].Value);
     }
 
@@ -97,7 +97,7 @@ public class ConsumerProcessAsyncTests : IDisposable
     public async Task MetricsConsumer_NegativeValue()
     {
         var consumer = new TestableMetricsConsumer(ScopeFactory);
-        await consumer.ProcessAsync("k", new MetricsMessage("s", "delta", -42.5, null, DateTime.UtcNow, null), default);
+        await consumer.ProcessAsync("k", MetricsMessage.ForGauge("s", "delta", -42.5, null, DateTime.UtcNow, null), default);
         Assert.Equal(-42.5, _clickHouse.WrittenMetrics[0].Value);
     }
 
@@ -105,8 +105,8 @@ public class ConsumerProcessAsyncTests : IDisposable
     public async Task MetricsConsumer_EmptyStringName()
     {
         var consumer = new TestableMetricsConsumer(ScopeFactory);
-        await consumer.ProcessAsync("k", new MetricsMessage("s", "", 1.0, null, DateTime.UtcNow, null), default);
-        Assert.Equal("", _clickHouse.WrittenMetrics[0].Name);
+        await consumer.ProcessAsync("k", MetricsMessage.ForGauge("s", "", 1.0, null, DateTime.UtcNow, null), default);
+        Assert.Equal("", _clickHouse.WrittenMetrics[0].MetricName);
     }
 
     [Fact]
@@ -114,8 +114,8 @@ public class ConsumerProcessAsyncTests : IDisposable
     {
         var consumer = new TestableMetricsConsumer(ScopeFactory);
         var tags = Enumerable.Range(0, 20).ToDictionary(i => $"tag{i}", i => $"val{i}");
-        await consumer.ProcessAsync("k", new MetricsMessage("s", "m", 1.0, "cat", DateTime.UtcNow, tags), default);
-        Assert.Equal(20, _clickHouse.WrittenMetrics[0].Tags!.Count);
+        await consumer.ProcessAsync("k", MetricsMessage.ForGauge("s", "m", 1.0, "cat", DateTime.UtcNow, tags), default);
+        Assert.Equal(20, _clickHouse.WrittenMetrics[0].Attributes!.Count);
     }
 
     // ══════════════════════════════════════════════════════════════════
@@ -293,8 +293,8 @@ public class ConsumerProcessAsyncTests : IDisposable
     [Fact]
     public void MetricsMessage_Equality()
     {
-        var a = new MetricsMessage("s", "m", 1.0, "c", DateTime.UnixEpoch, null);
-        var b = new MetricsMessage("s", "m", 1.0, "c", DateTime.UnixEpoch, null);
+        var a = MetricsMessage.ForGauge("s", "m", 1.0, "c", DateTime.UnixEpoch, null);
+        var b = MetricsMessage.ForGauge("s", "m", 1.0, "c", DateTime.UnixEpoch, null);
         Assert.Equal(a, b);
     }
 
@@ -326,13 +326,20 @@ public class ConsumerProcessAsyncTests : IDisposable
     {
         public List<LogRowInput> WrittenLogs { get; } = [];
         public List<TraceRowInput> WrittenTraces { get; } = [];
-        public List<(int ProjectId, string Name, double Value, string? Category, DateTime Timestamp, Dictionary<string, string>? Tags, string? SessionId)> WrittenMetrics { get; } = [];
+        public List<(int ProjectId, string MetricName, double Value, string? MetricDescription, DateTime Timestamp, Dictionary<string, string>? Attributes, string? SessionId)> WrittenMetrics { get; } = [];
 
         public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct) { WrittenLogs.AddRange(logs); return Task.CompletedTask; }
         public Task WriteTracesAsync(IEnumerable<TraceRowInput> traces, CancellationToken ct) { WrittenTraces.AddRange(traces); return Task.CompletedTask; }
-        public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct)
+        public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default)
         {
-            WrittenMetrics.Add((projectId, metricName, metricValue, category, timestamp, tags, sessionSecureId));
+            // Tests treat empty Attributes as null for back-compat with the
+            // pre-MetricRowInput stub shape.
+            var tags = row.Attributes.Count > 0 ? row.Attributes : null;
+            // MetricDescription comes through as "" when the producer didn't
+            // set one; flatten that to null so old assertions on a missing
+            // category-equivalent still see null.
+            var desc = string.IsNullOrEmpty(row.MetricDescription) ? null : row.MetricDescription;
+            WrittenMetrics.Add((row.ProjectId, row.MetricName, row.Value, desc, row.Timestamp, tags, row.SecureSessionId));
             return Task.CompletedTask;
         }
 

--- a/src/dotnet/tests/HoldFast.Worker.Tests/DataSyncWorkerTests.cs
+++ b/src/dotnet/tests/HoldFast.Worker.Tests/DataSyncWorkerTests.cs
@@ -499,8 +499,7 @@ internal class FakeClickHouseService : ILogStore, ITraceStore, ISessionAnalytics
     public Task<List<string>> GetEventsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, string? eventName, CancellationToken ct) =>
         throw new NotImplementedException();
 
-    public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct) =>
-        Task.CompletedTask;
+    public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default) => Task.CompletedTask;
 
     public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct) =>
         Task.CompletedTask;

--- a/src/dotnet/tests/HoldFast.Worker.Tests/ErrorGroupingWorkerTests.cs
+++ b/src/dotnet/tests/HoldFast.Worker.Tests/ErrorGroupingWorkerTests.cs
@@ -273,21 +273,23 @@ public class ErrorGroupingWorkerTests : IDisposable
     public void MetricsMessage_AllFields()
     {
         var tags = new Dictionary<string, string> { ["host"] = "server-1" };
-        var msg = new MetricsMessage(
+        var msg = MetricsMessage.ForGauge(
             "sess-1", "cpu.usage", 85.5, "system",
             DateTime.UtcNow, tags);
 
-        Assert.Equal("cpu.usage", msg.Name);
+        Assert.Equal("cpu.usage", msg.MetricName);
         Assert.Equal(85.5, msg.Value);
-        Assert.Equal("system", msg.Category);
+        Assert.Equal("system", msg.MetricDescription);
     }
 
     [Fact]
     public void MetricsMessage_NullOptionalFields()
     {
-        var msg = new MetricsMessage("sess-1", "latency", 12.3, null, DateTime.UtcNow, null);
+        var msg = MetricsMessage.ForGauge("sess-1", "latency", 12.3, null, DateTime.UtcNow, null);
 
-        Assert.Null(msg.Category);
-        Assert.Null(msg.Tags);
+        // ForGauge maps a null category to an empty MetricDescription rather
+        // than leaving it null, so the round-trip JSON shape stays uniform.
+        Assert.Equal(string.Empty, msg.MetricDescription);
+        Assert.Null(msg.Attributes);
     }
 }

--- a/src/dotnet/tests/HoldFast.Worker.Tests/KafkaMessageSerializationTests.cs
+++ b/src/dotnet/tests/HoldFast.Worker.Tests/KafkaMessageSerializationTests.cs
@@ -18,57 +18,57 @@ public class KafkaMessageSerializationTests
     public void MetricsMessage_RoundTrip()
     {
         var ts = new DateTime(2026, 3, 20, 10, 0, 0, DateTimeKind.Utc);
-        var msg = new MetricsMessage("sess-1", "LCP", 2.5, "web-vital", ts,
+        var msg = MetricsMessage.ForGauge("sess-1", "LCP", 2.5, "web-vital", ts,
             new Dictionary<string, string> { ["page"] = "/home" });
 
         var json = JsonSerializer.Serialize(msg);
         var deserialized = JsonSerializer.Deserialize<MetricsMessage>(json);
 
         Assert.NotNull(deserialized);
-        Assert.Equal("sess-1", deserialized!.SessionSecureId);
-        Assert.Equal("LCP", deserialized.Name);
+        Assert.Equal("sess-1", deserialized!.SecureSessionId);
+        Assert.Equal("LCP", deserialized.MetricName);
         Assert.Equal(2.5, deserialized.Value);
-        Assert.Equal("web-vital", deserialized.Category);
+        Assert.Equal("web-vital", deserialized.MetricDescription);
         Assert.Equal(ts, deserialized.Timestamp);
-        Assert.Equal("/home", deserialized.Tags!["page"]);
+        Assert.Equal("/home", deserialized.Attributes!["page"]);
     }
 
     [Fact]
     public void MetricsMessage_NullOptionalFields_RoundTrip()
     {
-        var msg = new MetricsMessage("s", "m", 0.0, null, DateTime.UtcNow, null);
+        var msg = MetricsMessage.ForGauge("s", "m", 0.0, null, DateTime.UtcNow, null);
         var json = JsonSerializer.Serialize(msg);
         var deserialized = JsonSerializer.Deserialize<MetricsMessage>(json);
 
-        Assert.Null(deserialized!.Category);
-        Assert.Null(deserialized.Tags);
+        Assert.Equal(string.Empty, deserialized!.MetricDescription);
+        Assert.Null(deserialized.Attributes);
     }
 
     [Fact]
-    public void MetricsMessage_EmptyTags_RoundTrip()
+    public void MetricsMessage_EmptyAttributes_RoundTrip()
     {
-        var msg = new MetricsMessage("s", "m", 1.0, null, DateTime.UtcNow, new());
+        var msg = MetricsMessage.ForGauge("s", "m", 1.0, null, DateTime.UtcNow, new());
         var json = JsonSerializer.Serialize(msg);
         var deserialized = JsonSerializer.Deserialize<MetricsMessage>(json);
 
-        Assert.NotNull(deserialized!.Tags);
-        Assert.Empty(deserialized.Tags);
+        Assert.NotNull(deserialized!.Attributes);
+        Assert.Empty(deserialized.Attributes);
     }
 
     [Fact]
     public void MetricsMessage_SpecialCharInName()
     {
-        var msg = new MetricsMessage("s", "metric.name/with-special_chars", 1.0, null, DateTime.UtcNow, null);
+        var msg = MetricsMessage.ForGauge("s", "metric.name/with-special_chars", 1.0, null, DateTime.UtcNow, null);
         var json = JsonSerializer.Serialize(msg);
         var deserialized = JsonSerializer.Deserialize<MetricsMessage>(json);
 
-        Assert.Equal("metric.name/with-special_chars", deserialized!.Name);
+        Assert.Equal("metric.name/with-special_chars", deserialized!.MetricName);
     }
 
     [Fact]
     public void MetricsMessage_VeryLargeValue()
     {
-        var msg = new MetricsMessage("s", "m", double.MaxValue, null, DateTime.UtcNow, null);
+        var msg = MetricsMessage.ForGauge("s", "m", double.MaxValue, null, DateTime.UtcNow, null);
         var json = JsonSerializer.Serialize(msg);
         var deserialized = JsonSerializer.Deserialize<MetricsMessage>(json);
 
@@ -225,7 +225,7 @@ public class KafkaMessageSerializationTests
     [Fact]
     public void MetricsMessage_JsonDoesNotMatchLogMessage()
     {
-        var msg = new MetricsMessage("s", "m", 1.0, null, DateTime.UtcNow, null);
+        var msg = MetricsMessage.ForGauge("s", "m", 1.0, null, DateTime.UtcNow, null);
         var json = JsonSerializer.Serialize(msg);
 
         // Deserializing as LogIngestionMessage should produce an object with wrong/default values

--- a/src/dotnet/tests/HoldFast.Worker.Tests/LogAlertWatcherWorkerTests.cs
+++ b/src/dotnet/tests/HoldFast.Worker.Tests/LogAlertWatcherWorkerTests.cs
@@ -351,8 +351,7 @@ internal class FakeLogClickHouseService : ILogStore, ITraceStore, ISessionAnalyt
         throw new NotImplementedException();
     public Task<List<string>> GetEventsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, string? eventName, CancellationToken ct) =>
         throw new NotImplementedException();
-    public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct) =>
-        Task.CompletedTask;
+    public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default) => Task.CompletedTask;
     public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct) =>
         Task.CompletedTask;
     public Task WriteTracesAsync(IEnumerable<TraceRowInput> traces, CancellationToken ct) =>

--- a/src/dotnet/tests/HoldFast.Worker.Tests/MetricAlertWatcherWorkerTests.cs
+++ b/src/dotnet/tests/HoldFast.Worker.Tests/MetricAlertWatcherWorkerTests.cs
@@ -440,8 +440,7 @@ internal class FakeMetricClickHouseService : ILogStore, ITraceStore, ISessionAna
         throw new NotImplementedException();
     public Task<List<string>> GetEventsKeyValuesAsync(int projectId, string keyName, DateTime startDate, DateTime endDate, string? query, int? count, string? eventName, CancellationToken ct) =>
         throw new NotImplementedException();
-    public Task WriteMetricAsync(int projectId, string metricName, double metricValue, string? category, DateTime timestamp, Dictionary<string, string>? tags, string? sessionSecureId, CancellationToken ct) =>
-        Task.CompletedTask;
+    public Task WriteMetricAsync(MetricRowInput row, CancellationToken ct = default) => Task.CompletedTask;
     public Task WriteLogsAsync(IEnumerable<LogRowInput> logs, CancellationToken ct) =>
         Task.CompletedTask;
     public Task WriteTracesAsync(IEnumerable<TraceRowInput> traces, CancellationToken ct) =>

--- a/src/dotnet/tests/HoldFast.Worker.Tests/WorkerMessageRecordTests.cs
+++ b/src/dotnet/tests/HoldFast.Worker.Tests/WorkerMessageRecordTests.cs
@@ -1,3 +1,5 @@
+using HoldFast.Analytics.Models;
+
 namespace HoldFast.Worker.Tests;
 
 public class SessionEventsMessageTests
@@ -182,113 +184,85 @@ public class BackendErrorMessageTests
 
 public class MetricsMessageTests
 {
+    private static MetricsMessage Gauge(
+        string sessionId = "s", string name = "m", double value = 1.0,
+        string? category = null, DateTime? timestamp = null,
+        Dictionary<string, string>? tags = null) =>
+        MetricsMessage.ForGauge(sessionId, name, value, category, timestamp ?? DateTime.UtcNow, tags);
+
     [Fact]
     public void MetricsMessage_HasRequiredFields()
     {
-        var msg = new MetricsMessage(
-            SessionSecureId: "sess-1",
-            Name: "LCP",
-            Value: 2.5,
-            Category: "web-vital",
-            Timestamp: DateTime.UtcNow,
-            Tags: new Dictionary<string, string> { ["page"] = "/home" });
+        var msg = Gauge("sess-1", "LCP", 2.5, "web-vital",
+            tags: new Dictionary<string, string> { ["page"] = "/home" });
 
-        Assert.Equal("LCP", msg.Name);
+        Assert.Equal("LCP", msg.MetricName);
         Assert.Equal(2.5, msg.Value);
-        Assert.Single(msg.Tags!);
+        Assert.Equal(MetricKind.Gauge, msg.Kind);
+        Assert.Single(msg.Attributes!);
     }
 
     [Fact]
-    public void MetricsMessage_NullableTagsAllowed()
+    public void MetricsMessage_NullableAttributesAllowed()
     {
-        var msg = new MetricsMessage(
-            SessionSecureId: "sess-1",
-            Name: "request_duration",
-            Value: 150.0,
-            Category: null,
-            Timestamp: DateTime.UtcNow,
-            Tags: null);
+        var msg = Gauge("sess-1", "request_duration", 150.0, null, tags: null);
 
-        Assert.Null(msg.Tags);
-        Assert.Null(msg.Category);
+        Assert.Null(msg.Attributes);
+        Assert.Equal(string.Empty, msg.MetricDescription);
     }
 
     [Fact]
-    public void MetricsMessage_ZeroValue()
+    public void MetricsMessage_ZeroValue() =>
+        Assert.Equal(0.0, Gauge(value: 0.0).Value);
+
+    [Fact]
+    public void MetricsMessage_NegativeValue() =>
+        Assert.Equal(-100.50, Gauge(value: -100.50).Value);
+
+    [Fact]
+    public void MetricsMessage_PositiveInfinity() =>
+        Assert.Equal(double.PositiveInfinity, Gauge(value: double.PositiveInfinity).Value);
+
+    [Fact]
+    public void MetricsMessage_NaN() =>
+        Assert.True(double.IsNaN(Gauge(value: double.NaN).Value));
+
+    [Fact]
+    public void MetricsMessage_EmptyAttributes()
     {
-        var msg = new MetricsMessage("s", "counter", 0.0, null, DateTime.UtcNow, null);
-        Assert.Equal(0.0, msg.Value);
+        var msg = Gauge(tags: new Dictionary<string, string>());
+        Assert.NotNull(msg.Attributes);
+        Assert.Empty(msg.Attributes!);
     }
 
     [Fact]
-    public void MetricsMessage_NegativeValue()
-    {
-        var msg = new MetricsMessage("s", "balance", -100.50, null, DateTime.UtcNow, null);
-        Assert.Equal(-100.50, msg.Value);
-    }
-
-    [Fact]
-    public void MetricsMessage_PositiveInfinity()
-    {
-        var msg = new MetricsMessage("s", "infinity", double.PositiveInfinity, null, DateTime.UtcNow, null);
-        Assert.Equal(double.PositiveInfinity, msg.Value);
-    }
-
-    [Fact]
-    public void MetricsMessage_NaN()
-    {
-        var msg = new MetricsMessage("s", "nan", double.NaN, null, DateTime.UtcNow, null);
-        Assert.True(double.IsNaN(msg.Value));
-    }
-
-    [Fact]
-    public void MetricsMessage_EmptyTags()
-    {
-        var msg = new MetricsMessage("s", "m", 1.0, null, DateTime.UtcNow,
-            new Dictionary<string, string>());
-        Assert.NotNull(msg.Tags);
-        Assert.Empty(msg.Tags!);
-    }
-
-    [Fact]
-    public void MetricsMessage_ManyTags()
+    public void MetricsMessage_ManyAttributes()
     {
         var tags = Enumerable.Range(0, 100)
             .ToDictionary(i => $"key{i}", i => $"val{i}");
-
-        var msg = new MetricsMessage("s", "m", 1.0, null, DateTime.UtcNow, tags);
-        Assert.Equal(100, msg.Tags!.Count);
+        var msg = Gauge(tags: tags);
+        Assert.Equal(100, msg.Attributes!.Count);
     }
 
     [Fact]
-    public void MetricsMessage_MinDateTimestamp()
-    {
-        var msg = new MetricsMessage("s", "m", 1.0, null, DateTime.MinValue, null);
-        Assert.Equal(DateTime.MinValue, msg.Timestamp);
-    }
+    public void MetricsMessage_MinDateTimestamp() =>
+        Assert.Equal(DateTime.MinValue, Gauge(timestamp: DateTime.MinValue).Timestamp);
 
     [Fact]
-    public void MetricsMessage_MaxDateTimestamp()
-    {
-        var msg = new MetricsMessage("s", "m", 1.0, null, DateTime.MaxValue, null);
-        Assert.Equal(DateTime.MaxValue, msg.Timestamp);
-    }
+    public void MetricsMessage_MaxDateTimestamp() =>
+        Assert.Equal(DateTime.MaxValue, Gauge(timestamp: DateTime.MaxValue).Timestamp);
 
     [Fact]
     public void MetricsMessage_RecordEquality()
     {
         var ts = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        var msg1 = new MetricsMessage("s", "m", 1.0, "c", ts, null);
-        var msg2 = new MetricsMessage("s", "m", 1.0, "c", ts, null);
-        Assert.Equal(msg1, msg2);
+        Assert.Equal(Gauge("s", "m", 1.0, "c", ts), Gauge("s", "m", 1.0, "c", ts));
     }
 
     [Fact]
     public void MetricsMessage_RecordInequality_DifferentValue()
     {
         var ts = DateTime.UtcNow;
-        var msg1 = new MetricsMessage("s", "m", 1.0, null, ts, null);
-        var msg2 = new MetricsMessage("s", "m", 2.0, null, ts, null);
-        Assert.NotEqual(msg1, msg2);
+        Assert.NotEqual(Gauge("s", "m", 1.0, null, ts), Gauge("s", "m", 2.0, null, ts));
     }
 }

--- a/src/dotnet/tests/HoldFast.Worker.Tests/WorkerMessageTests.cs
+++ b/src/dotnet/tests/HoldFast.Worker.Tests/WorkerMessageTests.cs
@@ -233,14 +233,14 @@ public class WorkerMessageTests
     }
 
     [Fact]
-    public void MetricsMessage_WithTags()
+    public void MetricsMessage_WithAttributes()
     {
-        var msg = new MetricsMessage(
+        var msg = MetricsMessage.ForGauge(
             "session-1", "cpu.usage", 85.5, "system",
             DateTime.UtcNow,
             new Dictionary<string, string> { ["host"] = "web-01", ["region"] = "us-east" });
 
-        Assert.Equal(2, msg.Tags!.Count);
-        Assert.Equal("web-01", msg.Tags["host"]);
+        Assert.Equal(2, msg.Attributes!.Count);
+        Assert.Equal("web-01", msg.Attributes["host"]);
     }
 }

--- a/tests/soak/verify.sh
+++ b/tests/soak/verify.sh
@@ -67,8 +67,9 @@ case "$BACKEND" in
         report sessions "$(ch_query "SELECT count() FROM traces WHERE ServiceName = '$SVC' AND TraceAttributes['session.scenario'] = 'sessions'")" "$MIN"
         report events  "$(ch_query "SELECT count() FROM logs WHERE ServiceName = '$SVC' AND LogAttributes['log.scenario'] = 'events'")"  "$MIN"
 
-        # Metrics live in metrics_sum and have a slightly different filter shape.
-        report metrics "$(ch_query "SELECT count() FROM metrics_sum WHERE Tags.Value[indexOf(Tags.Name, 'metric.scenario')] = 'metrics'")" "$MIN"
+        # Metrics_sum stores Sum + Gauge in the OTeL-shaped schema (HOL-42);
+        # data-point attributes live in the Attributes Map column.
+        report metrics "$(ch_query "SELECT count() FROM metrics_sum WHERE Attributes['metric.scenario'] = 'metrics'")" "$MIN"
 
         echo
         echo "Distinct error groups (target: ~20 stable groups from errors.mjs):"


### PR DESCRIPTION
## Summary

Closes HOL-42. The previous `WriteMetricAsync` issued an INSERT against columns that no longer existed in `metrics_sum` (`MetricValue`, `Category`, `Tags.Name`, `Tags.Value`, `SecureSessionId`), so every metric write silently errored with "Unknown column" and the soak harness reported zero metric rows on the ClickHouse backend. Upstream Highlight migrated the metric tables to the OTeL collector shape — this PR rewires the ingest path to match.

## Changes

**Domain model** (`HoldFast.Analytics`)
- New `MetricRowInput` in `WriteInputs.cs` carries the full OTeL envelope: `ProjectId`, `ServiceName`, `MetricName`, `MetricDescription`, `MetricUnit`, `Attributes` (Map), `MetricType` (via a new `MetricKind` enum aligned with the CH Enum8), `StartTimestamp`, `Timestamp`, plus per-kind fields (Sum/Gauge: `Value`, `AggregationTemporality`, `IsMonotonic`; Histogram: `Count`, `Sum`, `BucketCounts`, `ExplicitBounds`, `Min`, `Max`).
- `IMetricStore.WriteMetricAsync` now takes a `MetricRowInput` instead of the (name, value, tags, category) tuple.

**ClickHouse store**
- `WriteMetricAsync` dispatches by `Kind`: Sum/Gauge/Empty → `metrics_sum` with the discriminator column populated, Histogram/ExponentialHistogram → `metrics_histogram`, Summary → `metrics_summary`. Attributes Maps are populated via `mapFromArrays(keys, values)` matching the HOL-43 logs/traces fix.

**Postgres store**
- Flattens the rich shape onto the single `analytics.metrics` table. Histogram/Summary use `Sum` as the surfaced numeric so the PG dashboard still gets a usable value; full bucket detail isn't kept on PG today.

**OTLP receiver**
- `OtelEndpoints.ParseOtelMetricsRich` walks `resourceMetrics → scopeMetrics → metrics`, emits per-kind `MetricsMessage` envelopes, and `HandleMetrics` publishes directly via `IMessageBus` (skipping the legacy narrow `MetricInput` so histogram bucket fields aren't lost).
- The protobuf path stays narrow (NumberDataPoint only) — incoming protobuf metrics are promoted to Gauge MetricsMessages until the protobuf parser is widened.

**SDK push path**
- `KafkaProducerAdapter.ProduceMetricAsync` translates `MetricInput` (GraphQL public input) to the same `MetricsMessage` shape — consumer only ever deals with one type.

**Worker**
- `MetricsMessage` reshaped to mirror the OTeL data-point envelope. `MetricsMessage.ForGauge` factory keeps test sites that only need (sessionId, name, value, category, ts, tags) ergonomic.
- `MetricsConsumer.ProcessAsync` builds a `MetricRowInput` and calls the new store signature.

**Tests**
- 12 test files updated to match the new `IMetricStore.WriteMetricAsync` signature (mostly one-line stubs in test fakes).
- A few semantic asserts adjusted: `MetricDescription` is now empty-string-not-null when not set, since OTeL doesn't carry a NULL marker for that field.
- `tests/soak/verify.sh` switches the CH metrics query from `Tags.Value[indexOf(Tags.Name, 'metric.scenario')]` (Nested syntax against columns that don't exist anymore) to `Attributes['metric.scenario']` (Map syntax against the actual column).

## Verification

```
# CH backend
verify.sh:
  ok logs 52 ok traces 25 ok errors 45 ok sessions 12 ok events 8 ok metrics 9
  6/6 scenarios green

# PG backend
STORAGE_ANALYTICS=Postgres verify.sh:
  ok logs 33 ok traces 21 ok errors 72 ok sessions 14 ok events 5 ok metrics 39
  6/6 scenarios green
```

Existing **3,153 .NET unit tests pass** against the new shape. Backend builds clean (0 warnings, 0 errors).

## Test plan

- [x] CH backend reports 6/6 on verify.sh (metrics now lands in metrics_sum)
- [x] PG backend remains 6/6 on verify.sh
- [x] All 3,153 unit tests pass
- [x] Backend builds with no warnings or errors
- [ ] Real 24h soak run (separate, after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)