### PR TITLE
Drop ILogger from UserRequestInterceptor — fixes dashboard login (HOL-44)

### DIFF
--- a/src/dotnet/src/HoldFast.Api/UserRequestInterceptor.cs
+++ b/src/dotnet/src/HoldFast.Api/UserRequestInterceptor.cs
@@ -2,7 +2,6 @@ using HoldFast.Shared.Auth;
 using HotChocolate.AspNetCore;
 using HotChocolate.Execution;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 
 namespace HoldFast.Api;
 
@@ -10,28 +9,20 @@ namespace HoldFast.Api;
 /// HC request interceptor that copies HttpContext.User (set by AuthMiddleware)
 /// into HC's global state so resolver ClaimsPrincipal parameters resolve correctly.
 /// Without this, HC resolvers receive an empty/unauthenticated ClaimsPrincipal.
+///
+/// Intentionally has no constructor dependencies: HC 16 activates request
+/// interceptors against its own scoped provider, which does not include
+/// <c>ILogger&lt;T&gt;</c>. Injecting one made every /private GraphQL request
+/// 500 with "Unable to resolve service for type ILogger&lt;UserRequestInterceptor&gt;".
 /// </summary>
 public sealed class UserRequestInterceptor : DefaultHttpRequestInterceptor
 {
-    private readonly ILogger<UserRequestInterceptor> _logger;
-
-    public UserRequestInterceptor(ILogger<UserRequestInterceptor> logger)
-    {
-        _logger = logger;
-    }
-
     public override ValueTask OnCreateAsync(
         HttpContext context,
         IRequestExecutor requestExecutor,
         OperationRequestBuilder requestBuilder,
         CancellationToken cancellationToken)
     {
-        var uid = context.User?.FindFirst(HoldFastClaimTypes.Uid)?.Value;
-        var isAuth = context.User?.Identity?.IsAuthenticated ?? false;
-        _logger.LogInformation(
-            "UserRequestInterceptor: path={Path} isAuthenticated={IsAuth} uid={Uid}",
-            context.Request.Path, isAuth, uid ?? "(null)");
-
         // Forward the authenticated user into the GraphQL operation request.
         // HOL-16: HC 16 introduced OperationRequestBuilder.SetUser(...) which
         // replaces the old WellKnownContextData.UserState global-state pattern.


### PR DESCRIPTION
## Summary

Closes HOL-44. Every `/private` GraphQL request from the dashboard was 500ing because `UserRequestInterceptor` couldn't be activated — surfaced when logging into the dashboard for the first time post-HOL-16 (HC 16 migration).

```
System.InvalidOperationException: Unable to resolve service for type
'Microsoft.Extensions.Logging.ILogger`1[HoldFast.Api.UserRequestInterceptor]'
while attempting to activate 'HoldFast.Api.UserRequestInterceptor'.
```

HotChocolate 16 activates `IHttpRequestInterceptor` implementations against its own scoped service provider, which does NOT include `ILoggerFactory` / `ILogger<T>`. A host-side `AddSingleton<UserRequestInterceptor>()` doesn't help — HC bypasses the host container for interceptor activation.

## Fix

Drop the `ILogger` dependency. The single Information-level diagnostic line in `OnCreateAsync` was nice for debugging but not load-bearing. The actual job — forwarding `HttpContext.User` into the GraphQL operation request via `OperationRequestBuilder.SetUser` — is preserved.

## Why we didn't catch this earlier

The OTLP ingest path the soak exercises (`/otel/v1/*`) doesn't go through GraphQL, so `verify.sh` stayed 6/6 green throughout. This bug only manifested on `/private` GraphQL requests, and nothing in CI hits that path.

## Verification

```
TOKEN=$(curl -sS -X POST http://localhost:8082/auth/login \
  -d '{"email":"dev@holdfast.local","password":"password"}' | jq -r .token)

curl -sS http://localhost:8082/private \
  -H "Authorization: Bearer $TOKEN" \
  -d '{"query":"{ admin { id email name } }"}'
# HTTP 200 — {"data":{"admin":{"id":"1","email":"dev@holdfast.local","name":"Dev Admin"}}}
```

## Test plan

- [x] /private GraphQL returns 200 with admin data after login
- [x] Existing 3,153 unit tests still pass (no behavior changes outside the touched class)
- [ ] Manual dashboard smoke test — log in, view soak data

🤖 Generated with [Claude Code](https://claude.com/claude-code)