### PR TITLE
Remove Discord + Calendly book-a-call, point Github at HoldFast (HOL-46, HOL-51)

### DIFF
--- a/src/frontend/src/components/Header/Header.tsx
+++ b/src/frontend/src/components/Header/Header.tsx
@@ -58,7 +58,7 @@ import { Divider } from 'antd'
 import clsx from 'clsx'
 import moment from 'moment'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { FaDiscord, FaGithub } from 'react-icons/fa'
+import { FaGithub } from 'react-icons/fa'
 import { Link, matchRoutes, useLocation, useNavigate } from 'react-router-dom'
 import { useSessionStorage } from 'react-use'
 
@@ -66,7 +66,6 @@ import { useGetWorkspaceSettingsQuery } from '@/graph/generated/hooks'
 import { useIsSettingsPath } from '@/hooks/useIsSettingsPath'
 import { generateRandomColor } from '@/util/color'
 
-import { CalendlyButton } from '../CalendlyModal/CalendlyButton'
 import { CommandBar as CommandBarV1 } from './CommandBar/CommandBar'
 import styles from './Header.module.css'
 import InkeepChatSupportMenuItem from '@/components/Header/InkeepChatSupportMenuItem'
@@ -320,7 +319,6 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 							)}
 							{!isSettings && (
 								<Box display="flex" alignItems="center" gap="4">
-									<CalendlyButton />
 									<Box>
 										<ButtonIcon
 											cssClass={styles.button}
@@ -329,32 +327,7 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 											emphasis="high"
 											onClick={() => {
 												window.open(
-													'https://discord.gg/yxaXEAqgwN',
-													'_blank',
-												)
-											}}
-											icon={
-												<FaDiscord
-													style={{
-														height: 14,
-														width: 14,
-													}}
-													color={
-														vars.theme.interactive
-															.fill.secondary
-															.content.text
-													}
-												/>
-											}
-										/>
-										<ButtonIcon
-											cssClass={styles.button}
-											kind="secondary"
-											size="small"
-											emphasis="high"
-											onClick={() => {
-												window.open(
-													'https://github.com/highlight/highlight',
+													'https://github.com/BrewingCoder/holdfast',
 													'_blank',
 												)
 											}}

--- a/src/frontend/src/hooks/useInkeepSettings.ts
+++ b/src/frontend/src/hooks/useInkeepSettings.ts
@@ -44,15 +44,8 @@ const useInkeepSettings = (): InkeepSharedSettings => {
 			'https://storage.googleapis.com/organization-image-assets/highlightio-botAvatarSrcUrl-1718084264557.svg',
 		getHelpCallToActions: [
 			{
-				name: 'Discord',
-				url: 'https://discord.gg/yxaXEAqgwN',
-				icon: {
-					builtIn: 'FaDiscord',
-				},
-			},
-			{
 				name: 'Github',
-				url: 'https://github.com/highlight/highlight',
+				url: 'https://github.com/BrewingCoder/holdfast',
 				icon: {
 					builtIn: 'FaGithub',
 				},


### PR DESCRIPTION
## Summary

Three fork-leftover CTAs in the dashboard header that bled Highlight's SaaS branding into the self-hosted UI:

- **Book a call** — Calendly widget pointing at `calendly.com/highlight-io/application-support-sales`
- **Discord** icon — `discord.gg/yxaXEAqgwN` (Highlight community Discord; HoldFast has no Discord)
- **Github** icon — pointed at `github.com/highlight/highlight` rather than the HoldFast fork

All three removed from the header. The Github icon now points at `github.com/BrewingCoder/holdfast`.

`useInkeepSettings.ts` (AI chat help dropdown) had the same Discord + Highlight-Github links — same treatment.

Remaining Calendly call sites all live inside files HOL-49 deletes wholesale (Billing pages, `EnterpriseFeatureButton`), so the orphan `CalendlyModal` component + `react-calendly` dep get cleaned up in that follow-up PR.

Discord *notification integration* (alert webhooks routed to Discord channels) is a separate feature and stays — only branding / help-link references were touched here.

Closes HOL-46 (Calendly header removal — full delete in HOL-49).
Closes HOL-51 (Discord/Github links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)