### PR TITLE
chore: gitignore .mcp.json (inter-agent MCP config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ out
 build
 **/.next
 
+# Inter-agent MCP server config — points at our private lab URL and is
+# per-workspace, never shared between forks.
+.mcp.json
+
 apollo.config.js
 .yalc
 yalc.lock


### PR DESCRIPTION
Per-workspace, points at the private lab inter-agent server URL. Should never be committed. Adding to .gitignore so it can't be picked up by an accidental `git add .`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)