### PR TITLE
fix: EditProjectPlatforms tests align with List<string>? signature (HOL-55)

### DIFF
--- a/src/dotnet/tests/HoldFast.GraphQL.Tests/PrivateMutationMiscTests.cs
+++ b/src/dotnet/tests/HoldFast.GraphQL.Tests/PrivateMutationMiscTests.cs
@@ -369,7 +369,7 @@ public class PrivateMutationMiscTests : IDisposable
     public async Task EditProjectPlatforms_SetsPlatforms()
     {
         var result = await _mutation.EditProjectPlatforms(
-            _project.Id, "javascript,python,go",
+            _project.Id, new List<string> { "javascript", "python", "go" },
             _principal, _authz, _db, CancellationToken.None);
 
         Assert.True(result);
@@ -382,10 +382,10 @@ public class PrivateMutationMiscTests : IDisposable
     }
 
     [Fact]
-    public async Task EditProjectPlatforms_EmptyString_ClearsPlatforms()
+    public async Task EditProjectPlatforms_EmptyList_ClearsPlatforms()
     {
         var result = await _mutation.EditProjectPlatforms(
-            _project.Id, "",
+            _project.Id, new List<string>(),
             _principal, _authz, _db, CancellationToken.None);
 
         Assert.True(result);
@@ -395,16 +395,30 @@ public class PrivateMutationMiscTests : IDisposable
     }
 
     [Fact]
-    public async Task EditProjectPlatforms_TrimsWhitespace()
+    public async Task EditProjectPlatforms_Null_ClearsPlatforms()
+    {
+        var result = await _mutation.EditProjectPlatforms(
+            _project.Id, null,
+            _principal, _authz, _db, CancellationToken.None);
+
+        Assert.True(result);
+        var project = await _db.Projects.FindAsync(_project.Id);
+        Assert.NotNull(project!.Platforms);
+        Assert.Empty(project.Platforms!);
+    }
+
+    [Fact]
+    public async Task EditProjectPlatforms_TrimsWhitespaceAndDropsBlankEntries()
     {
         await _mutation.EditProjectPlatforms(
-            _project.Id, " javascript , python , go ",
+            _project.Id, new List<string> { " javascript ", "  ", " python ", "", " go " },
             _principal, _authz, _db, CancellationToken.None);
 
         var project = await _db.Projects.FindAsync(_project.Id);
-        Assert.Contains("javascript", project!.Platforms!);
-        Assert.Contains("python", project.Platforms!);
-        Assert.Contains("go", project.Platforms!);
+        Assert.Equal(3, project!.Platforms!.Count);
+        Assert.Contains("javascript", project.Platforms);
+        Assert.Contains("python", project.Platforms);
+        Assert.Contains("go", project.Platforms);
     }
 
     [Fact]
@@ -412,7 +426,7 @@ public class PrivateMutationMiscTests : IDisposable
     {
         await Assert.ThrowsAsync<GraphQLException>(() =>
             _mutation.EditProjectPlatforms(
-                99999, "javascript",
+                99999, new List<string> { "javascript" },
                 _principal, _authz, _db, CancellationToken.None));
     }
 
@@ -420,7 +434,7 @@ public class PrivateMutationMiscTests : IDisposable
     public async Task EditProjectPlatforms_SinglePlatform()
     {
         await _mutation.EditProjectPlatforms(
-            _project.Id, "javascript",
+            _project.Id, new List<string> { "javascript" },
             _principal, _authz, _db, CancellationToken.None);
 
         var project = await _db.Projects.FindAsync(_project.Id);
@@ -432,11 +446,11 @@ public class PrivateMutationMiscTests : IDisposable
     public async Task EditProjectPlatforms_OverwritesPrevious()
     {
         await _mutation.EditProjectPlatforms(
-            _project.Id, "javascript,python",
+            _project.Id, new List<string> { "javascript", "python" },
             _principal, _authz, _db, CancellationToken.None);
 
         await _mutation.EditProjectPlatforms(
-            _project.Id, "go,rust",
+            _project.Id, new List<string> { "go", "rust" },
             _principal, _authz, _db, CancellationToken.None);
 
         var project = await _db.Projects.FindAsync(_project.Id);

--- a/src/dotnet/tests/HoldFast.Shared.Tests/AnalyticsAndCommentTests.cs
+++ b/src/dotnet/tests/HoldFast.Shared.Tests/AnalyticsAndCommentTests.cs
@@ -427,7 +427,8 @@ public class AnalyticsAndCommentTests : IDisposable
     public async Task EditProjectPlatforms_UpdatesPlatforms()
     {
         await _mutation.EditProjectPlatforms(
-            _project.Id, "web,mobile,backend", _principal, _authz, _db, CancellationToken.None);
+            _project.Id, new List<string> { "web", "mobile", "backend" },
+            _principal, _authz, _db, CancellationToken.None);
 
         var project = await _db.Projects.FindAsync(_project.Id);
         Assert.Equal(3, project!.Platforms.Count);
@@ -437,13 +438,13 @@ public class AnalyticsAndCommentTests : IDisposable
     }
 
     [Fact]
-    public async Task EditProjectPlatforms_EmptyString_ClearsPlatforms()
+    public async Task EditProjectPlatforms_EmptyList_ClearsPlatforms()
     {
         _project.Platforms = ["web", "mobile"];
         await _db.SaveChangesAsync();
 
         await _mutation.EditProjectPlatforms(
-            _project.Id, "", _principal, _authz, _db, CancellationToken.None);
+            _project.Id, new List<string>(), _principal, _authz, _db, CancellationToken.None);
 
         var project = await _db.Projects.FindAsync(_project.Id);
         Assert.Empty(project!.Platforms);
@@ -453,6 +454,7 @@ public class AnalyticsAndCommentTests : IDisposable
     public async Task EditProjectPlatforms_NotFound_Throws()
     {
         await Assert.ThrowsAsync<GraphQLException>(() =>
-            _mutation.EditProjectPlatforms(9999, "web", _principal, _authz, _db, CancellationToken.None));
+            _mutation.EditProjectPlatforms(9999, new List<string> { "web" },
+                _principal, _authz, _db, CancellationToken.None));
     }
 }


### PR DESCRIPTION
## Summary

- Aligns 10 `EditProjectPlatforms` test cases with the `List<string>?` signature introduced in PR #128 (HOL-52).
- Renames two test cases whose names referenced the now-gone CSV semantics; adds a new `_Null_ClearsPlatforms` covering the nullable input path.
- Build was red on `main` since #128 merged. This PR returns the solution to a green build.

## Why this slipped

PR #128 fixed the `/connect/new` setup wizard by changing the GraphQL mutation signature from `string platforms` (CSV) to `List<string>? platforms` to match the array the frontend sends. The implementation, GraphQL schema, and frontend got updated — the 10 test callers did not. The PR shipped without running tests; CI is currently disabled.

## How it was caught

AIRM5/Tamp build-tool integration on `hol-54/airm5-build-tool` (HOL-54). First non-trivial `dotnet tamp Compile` target failed with 10 hard `CS1503` errors. Verified the legacy `dotnet build src/dotnet/HoldFast.Backend.slnx` hits the same 10 errors — not a Tamp issue, Tamp just surfaced it on day 1.

## Test plan

- [x] `dotnet build src/dotnet/HoldFast.Backend.slnx` → **0 errors** (6 pre-existing nullability warnings)
- [x] `dotnet test --filter EditProjectPlatforms` (GraphQL.Tests) → **7 passed, 0 failed**
- [x] `dotnet test --filter EditProjectPlatforms` (Shared.Tests) → **3 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)