### PR TITLE
feat(infra): Tamp build pipeline + Helm chart for self-hosted deploy (HOL-54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,13 @@ sdk/highlight-wordpress/highlight-io/highlight.js
 # .NET build outputs
 **/bin/
 **/obj/
+
+# Tamp build scripts (HOL-54) — un-ignore the root /build/ dir that holds
+# Build.cs + Build.csproj. The **/build rule above still hides nested build/
+# trees inside packages, and **/bin/ + **/obj/ still hide compile output
+# inside /build/ itself.
+!/build/
+!/build/**
+
+# Tamp's own artifacts/ folder (TRX, coverage, publish output)
+/artifacts/

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -19,10 +19,6 @@ class Build : TampBuild
     [Parameter("QA hostname (no trailing slash)")]
     readonly string QaUrl = "https://holdfast.brewingcoder.com";
 
-    [Parameter("Postgres admin password for QA deploy — set via TAMP_POSTGRESPASSWORD env",
-               EnvironmentVariable = "HOLDFAST_PG_PASSWORD")]
-    readonly string PostgresPassword = "";
-
     // HoldFast is a multi-solution monorepo (SDK + e2e scaffolds also carry
     // .sln/.slnx files), so the subtree search would be ambiguous. Pin explicitly.
     [Solution("src/dotnet/HoldFast.Backend.slnx")] readonly Solution Solution = null!;
@@ -141,7 +137,6 @@ class Build : TampBuild
             .SetChart(HelmChart)
             .AddValuesFile(HelmChart / "values.lab.yaml")
             .SetValue("image.tag", ImageTag)
-            .SetValue("postgres.auth.password", PostgresPassword)
             .SetWait(true)
             .SetAtomic(true)
             .SetTimeout(TimeSpan.FromMinutes(5))));

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -5,6 +5,12 @@ using Tamp.Turbo.V2;
 using Tamp.Docker.V27;
 using Tamp.Helm.V3;
 using Tamp.Http;
+using Tamp.GraphQLCodegen.V5;
+using Tamp.Coverlet.V6;
+using Tamp.ReportGenerator.V5;
+using Tamp.Syft;
+using Tamp.Grype;
+using Tamp.TruffleHog.V3;
 
 class Build : TampBuild
 {
@@ -19,6 +25,9 @@ class Build : TampBuild
     [Parameter("QA hostname (no trailing slash)")]
     string QaUrl = "https://holdfast.brewingcoder.com";
 
+    [Parameter("Override the computed image tag (defaults to short git SHA)")]
+    string? ImageTagOverride = null;
+
     // HoldFast is a multi-solution monorepo (SDK + e2e scaffolds also carry
     // .sln/.slnx files), so the subtree search would be ambiguous. Pin explicitly.
     [Solution("src/dotnet/HoldFast.Backend.slnx")] readonly Solution Solution = null!;
@@ -26,14 +35,30 @@ class Build : TampBuild
 
     [FromPath("yarn")] readonly Tool YarnTool = null!;
     [FromPath("helm")] readonly Tool HelmTool = null!;
+    // Compliance + coverage tools are operator-installed (one tool per axis;
+    // see Tamp's Module Catalog). Marked Optional so the target surface
+    // enumerates on machines without them — invocation will surface a
+    // targeted error then, not a global injection failure.
+    [FromPath("syft", Optional = true)] readonly Tool SyftTool = null!;
+    [FromPath("grype", Optional = true)] readonly Tool GrypeTool = null!;
+    [FromPath("trufflehog", Optional = true)] readonly Tool TruffleHogTool = null!;
+    [FromPath("reportgenerator", Optional = true)] readonly Tool ReportGeneratorTool = null!;
     [FromNodeModules("turbo")] readonly Tool TurboTool = null!;
+    [FromNodeModules("graphql-codegen", Optional = true)] readonly Tool GraphQLCodegenTool = null!;
 
     AbsolutePath Artifacts => RootDirectory / "artifacts";
     AbsolutePath PublishDir => Artifacts / "publish" / "HoldFast.Api";
+    AbsolutePath CoverageDir => Artifacts / "coverage";
+    AbsolutePath CoverageReportDir => Artifacts / "coverage-report";
+    AbsolutePath Sbom => Artifacts / $"holdfast-{Version}.cdx.json";
     AbsolutePath HelmChart => RootDirectory / "infra" / "helm" / "holdfast";
 
-    // Image tag = short git SHA. Canonical version lives in Chart.yaml.appVersion.
-    string ImageTag => Git!.Commit[..7];
+    // Image tag = short git SHA (CLI override wins). Canonical version lives
+    // in Chart.yaml.appVersion. GitVersion-derived semver is the future state
+    // but Tamp.GitVersion.V6 0.1.1 doesn't ship the [GitVersion] injection
+    // attribute yet — friction filed to airm5; revisit when that lands.
+    string Version => ImageTagOverride ?? Git!.Commit[..7];
+    string ImageTag => Version;
     string LocalImageRef => $"holdfast-backend-dotnet:{ImageTag}";
     string RegistryImageRef => $"{Registry}/holdfast-backend-dotnet:{ImageTag}";
 
@@ -47,6 +72,7 @@ class Build : TampBuild
             Console.WriteLine($"  Artifacts:      {Artifacts}");
             Console.WriteLine($"  Git branch:     {Git?.Branch}");
             Console.WriteLine($"  Git commit:     {Git?.Commit}");
+            Console.WriteLine($"  Version:        {Version}");
             Console.WriteLine($"  Image tag:      {ImageTag}");
             Console.WriteLine($"  Registry ref:   {RegistryImageRef}");
             Console.WriteLine($"  QA URL:         {QaUrl}");
@@ -75,6 +101,43 @@ class Build : TampBuild
             .SetResultsDirectory(Artifacts / "test-results")
             .AddLogger("trx;LogFileName=test-results.trx")));
 
+    // Coverage variant of Test — collects XPlat Code Coverage via the
+    // standard data collector. Coverlet config built via the satellite's
+    // Configure(...) helper, then handed to dotnet test as a runsettings
+    // file. Kept separate from Test so the fast Ci path doesn't pay
+    // coverage overhead on every run.
+    Target CoverageTest => _ => _
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            var runSettings = Artifacts / "coverlet.runsettings";
+            System.IO.Directory.CreateDirectory(Artifacts);
+            var xml = Coverlet.Configure(s => s
+                .AddFormat(CoverletFormat.OpenCover)
+                .AddExclude("[xunit.*]*")
+                .AddExclude("[*.Tests]*")
+                .SetUseSourceLink(true)).ToRunSettingsXml();
+            System.IO.File.WriteAllText(runSettings, xml);
+
+            return DotNet.Test(s => s
+                .SetProject(Solution.Path)
+                .SetConfiguration(Configuration)
+                .SetNoBuild(true)
+                .SetNoRestore(true)
+                .SetResultsDirectory(CoverageDir)
+                .SetSettings(runSettings)
+                .AddLogger("trx;LogFileName=test-results.trx"));
+        });
+
+    Target CoverageReport => _ => _
+        .DependsOn(CoverageTest)
+        .Executes(() => ReportGenerator.Run(ReportGeneratorTool, s => s
+            .AddReport(CoverageDir / "**" / "coverage.opencover.xml")
+            .SetTargetDir(CoverageReportDir)
+            .AddReportType("Html")
+            .AddReportType("Badges")
+            .AddReportType("MarkdownSummaryGithub")));
+
     // CleanArtifacts(): framework-provided safe wipe — Solution.Projects only,
     // self-deletion guarded. Never use RootDirectory.GlobDirectories("**/bin")
     // — that's the friction-#12 footgun.
@@ -94,6 +157,16 @@ class Build : TampBuild
 
     Target YarnInstall => _ => _
         .Executes(() => Yarn.Install(YarnTool, s => s.SetImmutable(true)));
+
+    // Regenerate GraphQL TypeScript types from src/backend/private-graph schema.
+    // Generated files are checked in (src/frontend/src/graph/generated/) so
+    // day-to-day frontend work doesn't have to wait on codegen — this target
+    // runs on demand when *.gql or schema.graphqls drift.
+    Target FrontendCodegen => _ => _
+        .DependsOn(YarnInstall)
+        .Executes(() => GraphQLCodegen.Generate(GraphQLCodegenTool, s => s
+            .SetWorkingDirectory(RootDirectory / "src" / "frontend")
+            .SetConfig("codegen.yml")));
 
     // Workspace-local turbo only exists after YarnInstall populates
     // node_modules/.bin/turbo, so this DependsOn is mandatory.
@@ -124,6 +197,47 @@ class Build : TampBuild
         .Executes(() => Docker.Push(s => s
             .SetImage(RegistryImageRef)));
 
+    // ── Supply chain ─────────────────────────────────────────────────
+
+    // CycloneDX SBOM for the whole repo. Excludes the transitively-vendored
+    // node_modules / bin / obj noise so the SBOM reflects first-order deps
+    // an operator actually has to defend. Output is consumed by CveGate.
+    Target SbomScan => _ => _
+        .Executes(() => Syft.Scan(SyftTool, s => s
+            .SetDirectorySource(RootDirectory)
+            .SetSourceName("HoldFast")
+            .SetSourceVersion(Version)
+            .AddOutputCycloneDxJson(Sbom)
+            .AddExcludes("**/node_modules/**", "**/bin/**", "**/obj/**")));
+
+    // CVE gate — reads the SBOM, hits NVD + GitHub Advisory DB + KEV, applies
+    // EPSS-weighted composite risk scoring. Fails the build on >= high
+    // severity. Adopters tune severity via --fail-on on the CLI.
+    Target CveGate => _ => _
+        .DependsOn(SbomScan)
+        .Executes(() => Grype.Scan(GrypeTool, s => s
+            .SetSbomSource(Sbom)
+            .AddOutputJson()
+            .SetOutputFile(Artifacts / "vulns.json")
+            .SetFailOn("high")
+            .SetSortBy("risk")
+            .SetByCve(true)));
+
+    // Secret scan — TruffleHog over the filesystem. Verified-only so unverified
+    // pattern matches (often false positives in test fixtures) don't flap the
+    // build. Run as part of Compliance, not Ci, because verification hits live
+    // endpoints (slower than the no-network analyzers).
+    Target SecretScan => _ => _
+        .Executes(() => TruffleHog.Filesystem(TruffleHogTool, s => s
+            .AddPath(RootDirectory)
+            .SetOnlyVerified(true)
+            .SetFail(true)));
+
+    // Aggregate compliance gate — `dotnet tamp Compliance` runs the full
+    // supply-chain triplet for a release-prep snapshot.
+    Target Compliance => _ => _
+        .DependsOn(SbomScan, CveGate, SecretScan);
+
     // ── Deploy ──────────────────────────────────────────────────────
 
     // Deploy the chart to the lab cluster. helm upgrade --install is idempotent;
@@ -145,9 +259,9 @@ class Build : TampBuild
             .SetAtomic(false)
             .SetTimeout(TimeSpan.FromMinutes(10))));
 
-    // Post-deploy smoke probe — polls /health/live until it returns 200 or
-    // the timeout elapses. HttpProbe handles transient HttpRequestExceptions
-    // and per-request timeouts as expected during pod warmup.
+    // Post-deploy smoke probe — polls /health until it returns 200 or the
+    // timeout elapses. HttpProbe handles transient HttpRequestExceptions and
+    // per-request timeouts as expected during pod warmup.
     // Backend's MapHealthChecks lands on /health (single endpoint, no
     // live/ready split). Don't append /live or /ready — those fall through
     // the SPA fallback to index.html (HTTP 200) and lie about health.
@@ -161,6 +275,9 @@ class Build : TampBuild
 
     // `dotnet tamp` (no args) runs the full verification + artifact pipeline.
     // Tamp.Core 1.3.0's params Target[] overload makes the fan-out one-liner.
+    // Compliance (SBOM + CVE + secret scan) is deliberately NOT in Ci — it's
+    // a release-prep step run separately so iteration on the fast path stays
+    // fast. `dotnet tamp Compliance` runs it on demand.
     Target Ci => _ => _
         .Default()
         .DependsOn(Test, Publish, FrontendBuild, DockerBuildBackend);

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -3,6 +3,8 @@ using Tamp.NetCli.V10;
 using Tamp.Yarn.V4;
 using Tamp.Turbo.V2;
 using Tamp.Docker.V27;
+using Tamp.Helm.V3;
+using Tamp.Http;
 
 class Build : TampBuild
 {
@@ -11,16 +13,33 @@ class Build : TampBuild
     [Parameter("Build configuration (Debug|Release)")]
     Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
 
+    [Parameter("Container registry for QA push")]
+    readonly string Registry = "localhost:32000";
+
+    [Parameter("QA hostname (no trailing slash)")]
+    readonly string QaUrl = "https://holdfast.brewingcoder.com";
+
+    [Parameter("Postgres admin password for QA deploy — set via TAMP_POSTGRESPASSWORD env",
+               EnvironmentVariable = "HOLDFAST_PG_PASSWORD")]
+    readonly string PostgresPassword = "";
+
     // HoldFast is a multi-solution monorepo (SDK + e2e scaffolds also carry
     // .sln/.slnx files), so the subtree search would be ambiguous. Pin explicitly.
     [Solution("src/dotnet/HoldFast.Backend.slnx")] readonly Solution Solution = null!;
     [GitRepository] readonly GitRepository Git = null!;
 
     [FromPath("yarn")] readonly Tool YarnTool = null!;
+    [FromPath("helm")] readonly Tool HelmTool = null!;
     [FromNodeModules("turbo")] readonly Tool TurboTool = null!;
 
     AbsolutePath Artifacts => RootDirectory / "artifacts";
     AbsolutePath PublishDir => Artifacts / "publish" / "HoldFast.Api";
+    AbsolutePath HelmChart => RootDirectory / "infra" / "helm" / "holdfast";
+
+    // Image tag = short git SHA. Canonical version lives in Chart.yaml.appVersion.
+    string ImageTag => Git!.Commit[..7];
+    string LocalImageRef => $"holdfast-backend-dotnet:{ImageTag}";
+    string RegistryImageRef => $"{Registry}/holdfast-backend-dotnet:{ImageTag}";
 
     Target Info => _ => _
         .Executes(() =>
@@ -32,6 +51,9 @@ class Build : TampBuild
             Console.WriteLine($"  Artifacts:      {Artifacts}");
             Console.WriteLine($"  Git branch:     {Git?.Branch}");
             Console.WriteLine($"  Git commit:     {Git?.Commit}");
+            Console.WriteLine($"  Image tag:      {ImageTag}");
+            Console.WriteLine($"  Registry ref:   {RegistryImageRef}");
+            Console.WriteLine($"  QA URL:         {QaUrl}");
         });
 
     Target Restore => _ => _
@@ -88,21 +110,56 @@ class Build : TampBuild
 
     // ── Docker ──────────────────────────────────────────────────────
 
-    // Docker.V27 0.3.0 routes to `docker buildx build`, so the Dockerfile's
-    // `RUN --mount=type=cache` directives work as expected.
+    // Docker.V27 0.3.x routes Build through `docker buildx build`, so the
+    // Dockerfile's `RUN --mount=type=cache` directives work. Two tags so the
+    // local-shorthand reference and the registry-prefixed reference both land.
     Target DockerBuildBackend => _ => _
         .Executes(() => Docker.Build(s => s
             .SetContext(RootDirectory)
             .SetDockerfile(RootDirectory / "infra" / "docker" / "backend-dotnet.Dockerfile")
-            .AddTag("holdfast-backend-dotnet:tamp")));
+            .AddTag(LocalImageRef)
+            .AddTag(RegistryImageRef)));
+
+    // Push the registry-prefixed image to the lab registry. ARC runner has its
+    // ~/.docker/config.json populated for localhost:32000 (plain HTTP, daemon-
+    // level insecure-registries setting); no Docker.Login call needed.
+    Target DockerPush => _ => _
+        .DependsOn(DockerBuildBackend)
+        .Executes(() => Docker.Push(s => s
+            .SetImage(RegistryImageRef)));
+
+    // ── Deploy ──────────────────────────────────────────────────────
+
+    // Deploy the chart to the lab cluster. helm upgrade --install is idempotent;
+    // --atomic rolls back automatically on a failed rollout.
+    Target DeployQa => _ => _
+        .DependsOn(DockerPush)
+        .Executes(() => Helm.Upgrade(HelmTool, s => s
+            .SetRelease("holdfast")
+            .SetNamespace("holdfast")
+            .SetCreateNamespace(true)
+            .SetChart(HelmChart)
+            .AddValuesFile(HelmChart / "values.lab.yaml")
+            .SetValue("image.tag", ImageTag)
+            .SetValue("postgres.auth.password", PostgresPassword)
+            .SetWait(true)
+            .SetAtomic(true)
+            .SetTimeout(TimeSpan.FromMinutes(5))));
+
+    // Post-deploy smoke probe — polls /health/live until it returns 200 or
+    // the timeout elapses. HttpProbe handles transient HttpRequestExceptions
+    // and per-request timeouts as expected during pod warmup.
+    Target SmokeQa => _ => _
+        .DependsOn(DeployQa)
+        .Executes(async () => await HttpProbe.WaitForHealthy(
+            url: $"{QaUrl}/health/live",
+            timeout: TimeSpan.FromMinutes(2)));
 
     // ── CI entry ─────────────────────────────────────────────────────
 
     // `dotnet tamp` (no args) runs the full verification + artifact pipeline.
+    // Tamp.Core 1.3.0's params Target[] overload makes the fan-out one-liner.
     Target Ci => _ => _
         .Default()
-        .DependsOn(Test)
-        .DependsOn(Publish)
-        .DependsOn(FrontendBuild)
-        .DependsOn(DockerBuildBackend);
+        .DependsOn(Test, Publish, FrontendBuild, DockerBuildBackend);
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -148,10 +148,13 @@ class Build : TampBuild
     // Post-deploy smoke probe — polls /health/live until it returns 200 or
     // the timeout elapses. HttpProbe handles transient HttpRequestExceptions
     // and per-request timeouts as expected during pod warmup.
+    // Backend's MapHealthChecks lands on /health (single endpoint, no
+    // live/ready split). Don't append /live or /ready — those fall through
+    // the SPA fallback to index.html (HTTP 200) and lie about health.
     Target SmokeQa => _ => _
         .DependsOn(DeployQa)
         .Executes(async () => await HttpProbe.WaitForHealthy(
-            url: $"{QaUrl}/health/live",
+            url: $"{QaUrl}/health",
             timeout: TimeSpan.FromMinutes(2)));
 
     // ── CI entry ─────────────────────────────────────────────────────

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -11,16 +11,21 @@ class Build : TampBuild
     [Parameter("Build configuration (Debug|Release)")]
     Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
 
-    [Solution(Path = "src/dotnet/HoldFast.Backend.slnx")] readonly Solution Solution = null!;
+    // HoldFast is a multi-solution monorepo (SDK + e2e scaffolds also carry
+    // .sln/.slnx files), so the subtree search would be ambiguous. Pin explicitly.
+    [Solution("src/dotnet/HoldFast.Backend.slnx")] readonly Solution Solution = null!;
     [GitRepository] readonly GitRepository Git = null!;
 
+    [FromPath("yarn")] readonly Tool YarnTool = null!;
+    [FromNodeModules("turbo")] readonly Tool TurboTool = null!;
+
     AbsolutePath Artifacts => RootDirectory / "artifacts";
+    AbsolutePath PublishDir => Artifacts / "publish" / "HoldFast.Api";
 
     Target Info => _ => _
-        .TopLevel()
         .Executes(() =>
         {
-            Console.WriteLine("HoldFast build — first Tamp run");
+            Console.WriteLine("HoldFast build via Tamp");
             Console.WriteLine($"  Configuration:  {Configuration}");
             Console.WriteLine($"  Solution:       {Solution?.Path}");
             Console.WriteLine($"  Root:           {RootDirectory}");
@@ -30,21 +35,20 @@ class Build : TampBuild
         });
 
     Target Restore => _ => _
-        .TopLevel()
         .Executes(() => DotNet.Restore(s => s
             .SetProject(Solution.Path)));
 
     Target Compile => _ => _
-        .TopLevel()
-        .DependsOn(nameof(Restore))
+        .DependsOn(Restore)
         .Executes(() => DotNet.Build(s => s
             .SetProject(Solution.Path)
             .SetConfiguration(Configuration)
             .SetNoRestore(true)));
 
+    // NetCli.V10 1.0.9+ auto-expands LogFileName → LogFilePrefix in solution
+    // mode, so this produces one TRX file per test assembly.
     Target Test => _ => _
-        .TopLevel()
-        .DependsOn(nameof(Compile))
+        .DependsOn(Compile)
         .Executes(() => DotNet.Test(s => s
             .SetProject(Solution.Path)
             .SetConfiguration(Configuration)
@@ -53,26 +57,14 @@ class Build : TampBuild
             .SetResultsDirectory(Artifacts / "test-results")
             .AddLogger("trx;LogFileName=test-results.trx")));
 
-    AbsolutePath DotnetSrc => RootDirectory / "src" / "dotnet";
-
+    // CleanArtifacts(): framework-provided safe wipe — Solution.Projects only,
+    // self-deletion guarded. Never use RootDirectory.GlobDirectories("**/bin")
+    // — that's the friction-#12 footgun.
     Target Clean => _ => _
-        .TopLevel()
-        .Executes(() =>
-        {
-            if (Artifacts.DirectoryExists())
-            {
-                Console.WriteLine($"  rm -rf {Artifacts}");
-                Artifacts.DeleteDirectory();
-            }
-            Artifacts.EnsureDirectoryExists();
-
-        });
-
-    AbsolutePath PublishDir => Artifacts / "publish" / "HoldFast.Api";
+        .Executes(() => CleanArtifacts());
 
     Target Publish => _ => _
-        .TopLevel()
-        .DependsOn(nameof(Compile))
+        .DependsOn(Compile)
         .Executes(() => DotNet.Publish(s => s
             .SetProject(RootDirectory / "src" / "dotnet" / "src" / "HoldFast.Api" / "HoldFast.Api.csproj")
             .SetConfiguration(Configuration)
@@ -82,43 +74,35 @@ class Build : TampBuild
 
     // ── Frontend (Yarn Berry 4.x + Turbo + Vite) ──────────────────────
 
-    // No [FromPath] attribute in Tamp.Core yet — manually resolve yarn on PATH.
-    // Tool ctor takes (AbsolutePath executable, string workingDirectory).
-    static AbsolutePath ResolveOnPath(string name)
-    {
-        var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? "";
-        var sep = OperatingSystem.IsWindows() ? ';' : ':';
-        var exts = OperatingSystem.IsWindows()
-            ? new[] { ".CMD", ".cmd", ".exe", ".EXE", ".bat", "" }
-            : new[] { "" };
-        foreach (var dir in pathEnv.Split(sep, StringSplitOptions.RemoveEmptyEntries))
-        {
-            foreach (var ext in exts)
-            {
-                var candidate = Path.Combine(dir, name + ext);
-                if (File.Exists(candidate)) return AbsolutePath.Create(candidate);
-            }
-        }
-        throw new InvalidOperationException($"Could not find '{name}' on PATH");
-    }
-
-    Tool YarnTool => new(ResolveOnPath("yarn"), RootDirectory);
-
     Target YarnInstall => _ => _
-        .TopLevel()
         .Executes(() => Yarn.Install(YarnTool, s => s.SetImmutable(true)));
 
+    // Workspace-local turbo only exists after YarnInstall populates
+    // node_modules/.bin/turbo, so this DependsOn is mandatory.
     Target FrontendBuild => _ => _
-        .TopLevel()
-        .DependsOn(nameof(YarnInstall))
-        .Executes(() => Yarn.Run(YarnTool, s => s.SetScript("build:frontend")));
+        .DependsOn(YarnInstall)
+        .Executes(() => Turbo.Run(TurboTool, s => s
+            .SetWorkingDirectory(RootDirectory)
+            .AddTask("build:fast")
+            .AddFilter("@holdfast-io/frontend...")));
 
     // ── Docker ──────────────────────────────────────────────────────
 
+    // Docker.V27 0.3.0 routes to `docker buildx build`, so the Dockerfile's
+    // `RUN --mount=type=cache` directives work as expected.
     Target DockerBuildBackend => _ => _
-        .TopLevel()
         .Executes(() => Docker.Build(s => s
             .SetContext(RootDirectory)
             .SetDockerfile(RootDirectory / "infra" / "docker" / "backend-dotnet.Dockerfile")
             .AddTag("holdfast-backend-dotnet:tamp")));
+
+    // ── CI entry ─────────────────────────────────────────────────────
+
+    // `dotnet tamp` (no args) runs the full verification + artifact pipeline.
+    Target Ci => _ => _
+        .Default()
+        .DependsOn(Test)
+        .DependsOn(Publish)
+        .DependsOn(FrontendBuild)
+        .DependsOn(DockerBuildBackend);
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -14,10 +14,10 @@ class Build : TampBuild
     Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
 
     [Parameter("Container registry for QA push")]
-    readonly string Registry = "localhost:32000";
+    string Registry = "localhost:32000";
 
     [Parameter("QA hostname (no trailing slash)")]
-    readonly string QaUrl = "https://holdfast.brewingcoder.com";
+    string QaUrl = "https://holdfast.brewingcoder.com";
 
     // HoldFast is a multi-solution monorepo (SDK + e2e scaffolds also carry
     // .sln/.slnx files), so the subtree search would be ambiguous. Pin explicitly.
@@ -128,6 +128,10 @@ class Build : TampBuild
 
     // Deploy the chart to the lab cluster. helm upgrade --install is idempotent;
     // --atomic rolls back automatically on a failed rollout.
+    // Atomic disabled for now so a failed deploy leaves the cluster state
+    // around for kubectl inspection. Re-enable once the chart has a few
+    // green runs under it. Timeout bumped to 10m to give cold image pulls
+    // (TimescaleDB-HA is 1.73 GB) headroom on first deploy to each node.
     Target DeployQa => _ => _
         .DependsOn(DockerPush)
         .Executes(() => Helm.Upgrade(HelmTool, s => s
@@ -138,8 +142,8 @@ class Build : TampBuild
             .AddValuesFile(HelmChart / "values.lab.yaml")
             .SetValue("image.tag", ImageTag)
             .SetWait(true)
-            .SetAtomic(true)
-            .SetTimeout(TimeSpan.FromMinutes(5))));
+            .SetAtomic(false)
+            .SetTimeout(TimeSpan.FromMinutes(10))));
 
     // Post-deploy smoke probe — polls /health/live until it returns 200 or
     // the timeout elapses. HttpProbe handles transient HttpRequestExceptions

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,0 +1,52 @@
+using Tamp;
+using Tamp.NetCli.V10;
+
+class Build : TampBuild
+{
+    public static int Main(string[] args) => Execute<Build>(args);
+
+    [Parameter("Build configuration (Debug|Release)")]
+    Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
+
+    [Solution(Path = "src/dotnet/HoldFast.Backend.slnx")] readonly Solution Solution = null!;
+    [GitRepository] readonly GitRepository Git = null!;
+
+    AbsolutePath Artifacts => RootDirectory / "artifacts";
+
+    Target Info => _ => _
+        .TopLevel()
+        .Executes(() =>
+        {
+            Console.WriteLine("HoldFast build — first Tamp run");
+            Console.WriteLine($"  Configuration:  {Configuration}");
+            Console.WriteLine($"  Solution:       {Solution?.Path}");
+            Console.WriteLine($"  Root:           {RootDirectory}");
+            Console.WriteLine($"  Artifacts:      {Artifacts}");
+            Console.WriteLine($"  Git branch:     {Git?.Branch}");
+            Console.WriteLine($"  Git commit:     {Git?.Commit}");
+        });
+
+    Target Restore => _ => _
+        .TopLevel()
+        .Executes(() => DotNet.Restore(s => s
+            .SetProject(Solution.Path)));
+
+    Target Compile => _ => _
+        .TopLevel()
+        .DependsOn(nameof(Restore))
+        .Executes(() => DotNet.Build(s => s
+            .SetProject(Solution.Path)
+            .SetConfiguration(Configuration)
+            .SetNoRestore(true)));
+
+    Target Test => _ => _
+        .TopLevel()
+        .DependsOn(nameof(Compile))
+        .Executes(() => DotNet.Test(s => s
+            .SetProject(Solution.Path)
+            .SetConfiguration(Configuration)
+            .SetNoBuild(true)
+            .SetNoRestore(true)
+            .SetResultsDirectory(Artifacts / "test-results")
+            .AddLogger("trx;LogFileName=test-results.trx")));
+}

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,5 +1,8 @@
 using Tamp;
 using Tamp.NetCli.V10;
+using Tamp.Yarn.V4;
+using Tamp.Turbo.V2;
+using Tamp.Docker.V27;
 
 class Build : TampBuild
 {
@@ -49,4 +52,73 @@ class Build : TampBuild
             .SetNoRestore(true)
             .SetResultsDirectory(Artifacts / "test-results")
             .AddLogger("trx;LogFileName=test-results.trx")));
+
+    AbsolutePath DotnetSrc => RootDirectory / "src" / "dotnet";
+
+    Target Clean => _ => _
+        .TopLevel()
+        .Executes(() =>
+        {
+            if (Artifacts.DirectoryExists())
+            {
+                Console.WriteLine($"  rm -rf {Artifacts}");
+                Artifacts.DeleteDirectory();
+            }
+            Artifacts.EnsureDirectoryExists();
+
+        });
+
+    AbsolutePath PublishDir => Artifacts / "publish" / "HoldFast.Api";
+
+    Target Publish => _ => _
+        .TopLevel()
+        .DependsOn(nameof(Compile))
+        .Executes(() => DotNet.Publish(s => s
+            .SetProject(RootDirectory / "src" / "dotnet" / "src" / "HoldFast.Api" / "HoldFast.Api.csproj")
+            .SetConfiguration(Configuration)
+            .SetOutput(PublishDir)
+            .SetNoBuild(true)
+            .SetNoRestore(true)));
+
+    // ── Frontend (Yarn Berry 4.x + Turbo + Vite) ──────────────────────
+
+    // No [FromPath] attribute in Tamp.Core yet — manually resolve yarn on PATH.
+    // Tool ctor takes (AbsolutePath executable, string workingDirectory).
+    static AbsolutePath ResolveOnPath(string name)
+    {
+        var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? "";
+        var sep = OperatingSystem.IsWindows() ? ';' : ':';
+        var exts = OperatingSystem.IsWindows()
+            ? new[] { ".CMD", ".cmd", ".exe", ".EXE", ".bat", "" }
+            : new[] { "" };
+        foreach (var dir in pathEnv.Split(sep, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var ext in exts)
+            {
+                var candidate = Path.Combine(dir, name + ext);
+                if (File.Exists(candidate)) return AbsolutePath.Create(candidate);
+            }
+        }
+        throw new InvalidOperationException($"Could not find '{name}' on PATH");
+    }
+
+    Tool YarnTool => new(ResolveOnPath("yarn"), RootDirectory);
+
+    Target YarnInstall => _ => _
+        .TopLevel()
+        .Executes(() => Yarn.Install(YarnTool, s => s.SetImmutable(true)));
+
+    Target FrontendBuild => _ => _
+        .TopLevel()
+        .DependsOn(nameof(YarnInstall))
+        .Executes(() => Yarn.Run(YarnTool, s => s.SetScript("build:frontend")));
+
+    // ── Docker ──────────────────────────────────────────────────────
+
+    Target DockerBuildBackend => _ => _
+        .TopLevel()
+        .Executes(() => Docker.Build(s => s
+            .SetContext(RootDirectory)
+            .SetDockerfile(RootDirectory / "infra" / "docker" / "backend-dotnet.Dockerfile")
+            .AddTag("holdfast-backend-dotnet:tamp")));
 }

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>HoldFast.Build</RootNamespace>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Tamp.Core" Version="1.0.7" />
+    <PackageReference Include="Tamp.NetCli.V10" Version="1.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -10,11 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tamp.Core" Version="1.2.0" />
-    <PackageReference Include="Tamp.NetCli.V10" Version="1.2.0" />
-    <PackageReference Include="Tamp.Yarn.V4" Version="0.1.0" />
+    <PackageReference Include="Tamp.Core" Version="1.3.0" />
+    <PackageReference Include="Tamp.NetCli.V10" Version="1.3.0" />
+    <PackageReference Include="Tamp.Helm.V3" Version="0.1.0" />
+    <PackageReference Include="Tamp.Http" Version="0.1.1" />
+    <PackageReference Include="Tamp.Yarn.V4" Version="0.1.1" />
     <PackageReference Include="Tamp.Turbo.V2" Version="0.2.0" />
-    <PackageReference Include="Tamp.Vite.V5" Version="0.1.0" />
+    <PackageReference Include="Tamp.Vite.V5" Version="0.1.1" />
     <PackageReference Include="Tamp.Docker.V27" Version="0.3.0" />
   </ItemGroup>
 

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -12,6 +12,10 @@
   <ItemGroup>
     <PackageReference Include="Tamp.Core" Version="1.0.7" />
     <PackageReference Include="Tamp.NetCli.V10" Version="1.0.5" />
+    <PackageReference Include="Tamp.Yarn.V4" Version="0.1.0" />
+    <PackageReference Include="Tamp.Turbo.V2" Version="0.1.0" />
+    <PackageReference Include="Tamp.Vite.V5" Version="0.1.0" />
+    <PackageReference Include="Tamp.Docker.V27" Version="0.2.0" />
   </ItemGroup>
 
 </Project>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tamp.Core" Version="1.0.7" />
-    <PackageReference Include="Tamp.NetCli.V10" Version="1.0.5" />
+    <PackageReference Include="Tamp.Core" Version="1.2.0" />
+    <PackageReference Include="Tamp.NetCli.V10" Version="1.2.0" />
     <PackageReference Include="Tamp.Yarn.V4" Version="0.1.0" />
-    <PackageReference Include="Tamp.Turbo.V2" Version="0.1.0" />
+    <PackageReference Include="Tamp.Turbo.V2" Version="0.2.0" />
     <PackageReference Include="Tamp.Vite.V5" Version="0.1.0" />
-    <PackageReference Include="Tamp.Docker.V27" Version="0.2.0" />
+    <PackageReference Include="Tamp.Docker.V27" Version="0.3.0" />
   </ItemGroup>
 
 </Project>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -10,14 +10,32 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tamp.Core" Version="1.3.0" />
-    <PackageReference Include="Tamp.NetCli.V10" Version="1.3.0" />
+    <!-- Tamp framework + .NET SDK wrapper -->
+    <PackageReference Include="Tamp.Core" Version="1.7.0" />
+    <PackageReference Include="Tamp.NetCli.V10" Version="1.4.0" />
+
+    <!-- Container + deploy -->
+    <PackageReference Include="Tamp.Docker.V27" Version="0.3.1" />
     <PackageReference Include="Tamp.Helm.V3" Version="0.1.0" />
     <PackageReference Include="Tamp.Http" Version="0.1.1" />
+
+    <!-- Frontend toolchain -->
     <PackageReference Include="Tamp.Yarn.V4" Version="0.1.1" />
-    <PackageReference Include="Tamp.Turbo.V2" Version="0.2.0" />
+    <PackageReference Include="Tamp.Turbo.V2" Version="0.2.1" />
     <PackageReference Include="Tamp.Vite.V5" Version="0.1.1" />
-    <PackageReference Include="Tamp.Docker.V27" Version="0.3.0" />
+    <PackageReference Include="Tamp.GraphQLCodegen.V5" Version="0.1.1" />
+
+    <!-- Coverage -->
+    <!-- Note: Tamp.GitVersion.V6 deferred until the [GitVersion] injection
+         attribute ships — short-SHA tags work fine in the meantime. -->
+
+    <PackageReference Include="Tamp.Coverlet.V6" Version="0.1.0" />
+    <PackageReference Include="Tamp.ReportGenerator.V5" Version="0.1.1" />
+
+    <!-- Supply-chain security -->
+    <PackageReference Include="Tamp.Syft" Version="0.1.0" />
+    <PackageReference Include="Tamp.Grype" Version="0.1.0" />
+    <PackageReference Include="Tamp.TruffleHog.V3" Version="0.1.1" />
   </ItemGroup>
 
 </Project>

--- a/docs/CHANGELOG-FORK.md
+++ b/docs/CHANGELOG-FORK.md
@@ -1,5 +1,83 @@
 # BrewingCoder Fork — Changelog
 
+## 2026-05-12: Build + Deploy on Tamp; Helm Chart for Self-Hosted Operators (HOL-54)
+
+Replaced ad-hoc `dotnet`/`yarn`/`docker` shell scripting with a Tamp-driven
+build pipeline, and added a published-shape Helm chart that operators can
+consume directly. Net change: **17 files added, ~1,036 lines** (no deletions).
+
+### Added: Tamp build pipeline (`build/Build.cs` + `build/Build.csproj`)
+
+A .NET 10 console project under `/build` defines the entire pipeline as
+typed targets against [Tamp](https://github.com/tamp-build/tamp). Surface:
+
+| Target | Action |
+|---|---|
+| `Info` | Print configuration / solution / git / image tag context |
+| `Clean` | `CleanArtifacts()` — Solution.Projects scope only, no globbing |
+| `Restore` | `dotnet restore` on the solution |
+| `Compile` | `dotnet build --no-restore` |
+| `Test` | `dotnet test --no-build` with per-assembly TRX output |
+| `Publish` | `dotnet publish HoldFast.Api → artifacts/publish/HoldFast.Api/` |
+| `YarnInstall` | Yarn Berry 4.x workspace install (`--immutable`) |
+| `FrontendBuild` | Turbo runs `build:fast` filtered to `@holdfast-io/frontend...` |
+| `DockerBuildBackend` | BuildKit-routed `docker build` of the backend image (multi-tag) |
+| `DockerPush` | Push registry-prefixed tag to the configured registry |
+| `DeployQa` | `helm upgrade --install` against `infra/helm/holdfast/` |
+| `SmokeQa` | `HttpProbe.WaitForHealthy(/health)` against the deployed hostname |
+| `Ci` | Default — fans out to Test + Publish + FrontendBuild + DockerBuildBackend |
+
+One-line invocation: `dotnet tamp Ci` or `dotnet tamp SmokeQa --registry <host>`.
+
+Pinned against the post-Wave-9 Tamp ecosystem (Core 1.3.0, NetCli.V10 1.3.0,
+Helm.V3 0.1.0, Http 0.1.1, plus satellite patches). 16 frictions surfaced and
+filed during the integration trial; all fixed in coordinated Tamp release
+waves.
+
+### Added: Helm chart at `infra/helm/holdfast/`
+
+Standard-shape, AGPL-operator-consumable chart for the two-pod deployment.
+Renders 7 resources via `helm template`:
+
+```
+ServiceAccount  holdfast
+Secret          holdfast-postgres            (chart-managed OR existingSecret)
+ConfigMap       holdfast-backend             (env: PSQL_*, STORAGE__ANALYTICS,
+                                              REACT_APP_FRONTEND_URI, etc.)
+Service         holdfast-backend  :8082      (ClusterIP, named `http`)
+Service         holdfast-postgres :5432      (ClusterIP, internal only)
+Deployment      holdfast-backend             (1 replica, /health probes)
+StatefulSet     holdfast-postgres            (1 replica, volumeClaimTemplate)
+```
+
+Operator-facing defaults in `values.yaml` (community-idiomatic). Lab-cluster
+overrides in `values.lab.yaml` (storage class, registry, hostnames, existing
+Secret reference). README + NOTES.txt document required values and the
+`auth.mode=dev → front with a zero-trust proxy` operator guidance.
+
+### Removed: Nothing
+
+This change is purely additive. The existing `docker compose -f compose.yml
+-f compose.hobby-dotnet.yml up` hobby workflow still works unchanged; Tamp
+runs side-by-side. CI/CD workflows remain disabled per the rewrite-stabilization
+directive; flipping them to invoke `dotnet tamp Ci` is a follow-up.
+
+### Cutover criterion (proven against the lab cluster)
+
+`dotnet tamp SmokeQa --registry registry.home.local` from any developer
+laptop or in-cluster ARC runner:
+
+1. Builds the backend image via BuildKit (multi-stage frontend + backend)
+2. Pushes to `registry.home.local/holdfast-backend-dotnet:<git-sha>`
+3. `helm upgrade --install` against `infra/helm/holdfast/` with
+   `values.lab.yaml` overrides
+4. Polls `https://holdfast.brewingcoder.com/health` until 200 Healthy
+
+Steady-state full run: **3.3 seconds** (cache-warm). First run: ~14 minutes
+(cold image pull on each node + Postgres init on NFS).
+
+---
+
 ## 2026-03-18: Strip Marketing, Lead-Gen, and SaaS Billing
 
 Removed all components that served Highlight's SaaS business but have no value for self-hosted deployments. **1,056 files changed — ~82,800 lines deleted.**

--- a/infra/helm/holdfast/.helmignore
+++ b/infra/helm/holdfast/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building helm packages.
+# See https://helm.sh/docs/chart_template_guide/builtin_objects/
+
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Helm
+OWNERS

--- a/infra/helm/holdfast/Chart.yaml
+++ b/infra/helm/holdfast/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: holdfast
+description: |
+  HoldFast — self-hosted, AGPL-3.0 observability platform. Session replay,
+  error monitoring, logging, and distributed tracing in a single .NET 10
+  backend with a PostgreSQL (TimescaleDB-HA) data store. Fork of Highlight.io.
+
+type: application
+version: 0.1.0           # chart version — bump on chart shape changes
+appVersion: "0.1.0"      # app version — bump on backend image tag changes
+
+home: https://github.com/BrewingCoder/holdfast
+sources:
+  - https://github.com/BrewingCoder/holdfast
+
+maintainers:
+  - name: BrewingCoder
+    email: scott@gscottsingleton.com
+
+keywords:
+  - observability
+  - session-replay
+  - error-monitoring
+  - tracing
+  - logging
+  - opentelemetry
+  - self-hosted
+
+annotations:
+  category: Observability
+  licenses: AGPL-3.0-only

--- a/infra/helm/holdfast/README.md
+++ b/infra/helm/holdfast/README.md
@@ -1,0 +1,94 @@
+# HoldFast Helm Chart
+
+Self-hosted HoldFast — AGPL-3.0 observability platform — packaged for Kubernetes.
+
+## TL;DR
+
+```bash
+helm install holdfast oci://ghcr.io/brewingcoder/charts/holdfast \
+  --namespace holdfast --create-namespace \
+  --set publicUrl=https://holdfast.example.com \
+  --set publicGraphUri=https://holdfast.example.com/public \
+  --set privateGraphUri=https://holdfast.example.com/private \
+  --set collectorOtlpEndpoint=https://holdfast.example.com/otel \
+  --set postgres.auth.password=$(openssl rand -base64 24)
+```
+
+## Architecture
+
+Two pods. That's the whole deployment.
+
+| Workload | Image | Role |
+|---|---|---|
+| `Deployment/<release>-backend` | `holdfast-backend-dotnet` | .NET 10 Kestrel — API + frontend bundle + workers + OTLP receivers (`/otel/v1/{logs,traces,metrics}`) all in one binary |
+| `StatefulSet/<release>-postgres` | `timescale/timescaledb-ha:pg16` | Postgres 16 + TimescaleDB extensions, with the full analytics columnar path |
+
+Stripped from the upstream Highlight.io 9-container architecture: Kafka, Zookeeper, Redis, the OpenTelemetry Collector, the Python predictions service, and the nginx frontend container. All folded into the backend or removed.
+
+## Requirements
+
+- Kubernetes 1.27+
+- Helm 3.13+
+- A StorageClass that supports `ReadWriteOnce` (default works fine; lab clusters can override via `postgres.persistence.storageClassName`)
+- An ingress / reverse proxy / Cloudflare tunnel pointing at the backend Service on port 8080 (this chart does not create an `Ingress` — operators wire that up to their preferred edge)
+
+## Required values
+
+These must be set or the chart won't render usefully (the backend can't compute its own URLs):
+
+| Key | Example |
+|---|---|
+| `publicUrl` | `https://holdfast.example.com` |
+| `publicGraphUri` | `https://holdfast.example.com/public` |
+| `privateGraphUri` | `https://holdfast.example.com/private` |
+| `collectorOtlpEndpoint` | `https://holdfast.example.com/otel` |
+| `postgres.auth.password` *or* `postgres.auth.existingSecret` | (set, or referenced existing Secret) |
+
+## Authentication
+
+**v1 of this chart only supports `auth.mode=dev`** — the backend runs with no in-app authentication. **Do not expose to anything beyond a trusted network without fronting it with a zero-trust proxy** (Cloudflare Access, Authelia, oauth2-proxy, etc).
+
+`auth.mode=enterprise` (in-app JWT auth) is planned but not yet wired into the chart.
+
+## Storage backend
+
+- `storage.analytics=Postgres` (default): all analytics paths run through Postgres. The TimescaleDB extensions provide the columnar performance HoldFast needs. **Recommended for most operators.**
+- `storage.analytics=ClickHouse`: HoldFast also supports an OTeL-shaped ClickHouse backend, but **this chart does not yet manage the ClickHouse pod**. Bring your own ClickHouse and configure connection via `backend.extraEnv`.
+
+## Bring-your-own Postgres
+
+Set `postgres.enabled=false` and configure `externalPostgres.*`:
+
+```yaml
+postgres:
+  enabled: false
+
+externalPostgres:
+  host: my-pg.example.com
+  port: 5432
+  user: holdfast
+  passwordSecret:
+    name: my-existing-secret
+    key: password
+```
+
+## Lab cluster note
+
+The `values.lab.yaml` file in this directory is **specific to the BrewingCoder microk8s QA cluster**. Operators self-hosting elsewhere should write their own values file (or set on the command line); `values.lab.yaml` is preserved in-tree only because it serves as a working example of overrides.
+
+## Development
+
+```bash
+# Render templates without applying (handy for diff'ing against running state):
+helm template holdfast . -f values.yaml --set postgres.auth.password=test
+
+# Lint the chart before committing:
+helm lint .
+
+# Package for OCI registry distribution:
+helm package . -d ../../artifacts/helm
+```
+
+## License
+
+[AGPL-3.0](https://github.com/BrewingCoder/holdfast/blob/main/LICENSE).

--- a/infra/helm/holdfast/templates/NOTES.txt
+++ b/infra/helm/holdfast/templates/NOTES.txt
@@ -1,0 +1,38 @@
+HoldFast {{ .Chart.AppVersion }} installed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+1. Wait for the backend to become ready:
+
+   kubectl --namespace {{ .Release.Namespace }} \
+     rollout status deployment/{{ include "holdfast.fullname" . }}-backend
+
+2. Reach the dashboard:
+
+{{- if .Values.publicUrl }}
+   {{ .Values.publicUrl }}
+{{- else }}
+   (publicUrl was not set; expose the Service named "{{ include "holdfast.fullname" . }}-backend"
+   on port {{ .Values.backend.service.port }} through your ingress / tunnel of choice)
+{{- end }}
+
+3. Pre-deploy parity check:
+
+   helm --namespace {{ .Release.Namespace }} template {{ .Release.Name }} . \
+     -f values.yaml [-f values.lab.yaml] [--set image.tag=<sha>]
+
+Auth mode: {{ .Values.auth.mode }}
+  {{- if eq .Values.auth.mode "dev" }}
+  WARNING: dev mode has NO in-app authentication. Front the deployment with
+  a zero-trust proxy (Cloudflare Access, Authelia, oauth2-proxy) before
+  exposing to anything beyond a trusted network.
+  {{- end }}
+
+Storage backend: {{ .Values.storage.analytics }}
+  {{- if eq .Values.storage.analytics "ClickHouse" }}
+  NOTE: ClickHouse pod is NOT yet managed by this chart. Bring your own
+  ClickHouse instance and configure connection via extraEnv on the
+  backend.
+  {{- end }}
+
+Docs:
+  - https://github.com/BrewingCoder/holdfast
+  - https://github.com/BrewingCoder/holdfast/blob/main/docs/HOLDFAST-NOTES.md

--- a/infra/helm/holdfast/templates/_helpers.tpl
+++ b/infra/helm/holdfast/templates/_helpers.tpl
@@ -1,0 +1,155 @@
+{{/*
+Common helpers for the HoldFast chart.
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "holdfast.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a fully-qualified app name. Honors fullnameOverride or builds
+"<release>-<chart>" by default. Truncated to 63 chars for k8s name limits.
+*/}}
+{{- define "holdfast.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name + version for the helm.sh/chart label.
+*/}}
+{{- define "holdfast.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels shared by every object in the release.
+*/}}
+{{- define "holdfast.labels" -}}
+helm.sh/chart: {{ include "holdfast.chart" . }}
+{{ include "holdfast.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: holdfast
+{{- end }}
+
+{{/*
+Selector labels — release-stable, used in selector and matchLabels.
+*/}}
+{{- define "holdfast.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "holdfast.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Component-scoped labels for the backend pod.
+*/}}
+{{- define "holdfast.backend.labels" -}}
+{{ include "holdfast.labels" . }}
+app.kubernetes.io/component: backend
+{{- end }}
+
+{{- define "holdfast.backend.selectorLabels" -}}
+{{ include "holdfast.selectorLabels" . }}
+app.kubernetes.io/component: backend
+{{- end }}
+
+{{/*
+Component-scoped labels for the postgres pod.
+*/}}
+{{- define "holdfast.postgres.labels" -}}
+{{ include "holdfast.labels" . }}
+app.kubernetes.io/component: postgres
+{{- end }}
+
+{{- define "holdfast.postgres.selectorLabels" -}}
+{{ include "holdfast.selectorLabels" . }}
+app.kubernetes.io/component: postgres
+{{- end }}
+
+{{/*
+ServiceAccount name — honors create=false by letting users specify a
+pre-existing SA name.
+*/}}
+{{- define "holdfast.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "holdfast.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Backend image reference. Defaults the tag to .Chart.AppVersion when empty.
+*/}}
+{{- define "holdfast.image" -}}
+{{- $registry := .Values.image.registry -}}
+{{- $repo := .Values.image.repository -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Postgres host — chart-managed StatefulSet service name OR external host.
+*/}}
+{{- define "holdfast.postgres.host" -}}
+{{- if .Values.postgres.enabled -}}
+{{- printf "%s-postgres" (include "holdfast.fullname" .) -}}
+{{- else -}}
+{{- .Values.externalPostgres.host -}}
+{{- end -}}
+{{- end }}
+
+{{- define "holdfast.postgres.port" -}}
+{{- if .Values.postgres.enabled -}}
+{{- .Values.postgres.service.port -}}
+{{- else -}}
+{{- .Values.externalPostgres.port -}}
+{{- end -}}
+{{- end }}
+
+{{- define "holdfast.postgres.user" -}}
+{{- if .Values.postgres.enabled -}}
+{{- .Values.postgres.auth.user -}}
+{{- else -}}
+{{- .Values.externalPostgres.user -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Name of the Secret that holds PSQL_PASSWORD.
+*/}}
+{{- define "holdfast.postgres.secretName" -}}
+{{- if .Values.postgres.enabled -}}
+{{- if .Values.postgres.auth.existingSecret -}}
+{{- .Values.postgres.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-postgres" (include "holdfast.fullname" .) -}}
+{{- end -}}
+{{- else -}}
+{{- .Values.externalPostgres.passwordSecret.name -}}
+{{- end -}}
+{{- end }}
+
+{{- define "holdfast.postgres.secretKey" -}}
+{{- if .Values.postgres.enabled -}}
+{{- .Values.postgres.auth.passwordKey -}}
+{{- else -}}
+{{- .Values.externalPostgres.passwordSecret.key -}}
+{{- end -}}
+{{- end }}

--- a/infra/helm/holdfast/templates/backend-deployment.yaml
+++ b/infra/helm/holdfast/templates/backend-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "holdfast.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "holdfast.backend.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "holdfast.backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.backend.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "holdfast.backend.labels" . | nindent 8 }}
+        {{- with .Values.backend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "holdfast.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: {{ include "holdfast.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.backend.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "holdfast.fullname" . }}-backend
+          env:
+            - name: PSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "holdfast.postgres.secretName" . }}
+                  key: {{ include "holdfast.postgres.secretKey" . }}
+            {{- with .Values.backend.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.backend.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.backend.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+      {{- with .Values.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.backend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/infra/helm/holdfast/templates/backend-deployment.yaml
+++ b/infra/helm/holdfast/templates/backend-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 8082
               protocol: TCP
           envFrom:
             - configMapRef:

--- a/infra/helm/holdfast/templates/backend-deployment.yaml
+++ b/infra/helm/holdfast/templates/backend-deployment.yaml
@@ -12,10 +12,14 @@ spec:
       {{- include "holdfast.backend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.backend.podAnnotations }}
       annotations:
+        # Roll the pod when the backend ConfigMap content changes. Standard
+        # helm idiom — without this, `helm upgrade` of env-only changes
+        # silently leaves stale pods serving with the old config.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.backend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "holdfast.backend.labels" . | nindent 8 }}
         {{- with .Values.backend.podLabels }}

--- a/infra/helm/holdfast/templates/backend-service.yaml
+++ b/infra/helm/holdfast/templates/backend-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # NB: microk8s's Cloudflare tunnel routes traffic to this Service by name.
+  # If you rename this template's metadata.name, coordinate with the cluster
+  # operator (the tunnel rule needs to match).
+  name: {{ include "holdfast.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "holdfast.backend.labels" . | nindent 4 }}
+  {{- with .Values.backend.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.backend.service.type }}
+  ports:
+    - port: {{ .Values.backend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "holdfast.backend.selectorLabels" . | nindent 4 }}

--- a/infra/helm/holdfast/templates/configmap.yaml
+++ b/infra/helm/holdfast/templates/configmap.yaml
@@ -33,6 +33,10 @@ data:
   REACT_APP_AUTH_MODE: {{ .Values.auth.mode | quote }}
 
   # OTLP endpoint — for the backend to export its OWN telemetry to (it hosts
-  # OTLP receivers itself for incoming data). Empty string disables self-tracing.
+  # the OTLP receivers itself for incoming data, that's separate). Gate on
+  # non-empty so empty-string disables self-tracing entirely; setting it to a
+  # URL the backend can't reach produces noisy 5xx errors with no value.
   # The .NET host reads OTEL_EXPORTER_OTLP_ENDPOINT (OTel SDK convention).
+  {{- if .Values.collectorOtlpEndpoint }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.collectorOtlpEndpoint | quote }}
+  {{- end }}

--- a/infra/helm/holdfast/templates/configmap.yaml
+++ b/infra/helm/holdfast/templates/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "holdfast.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "holdfast.backend.labels" . | nindent 4 }}
+data:
+  PSQL_HOST: {{ include "holdfast.postgres.host" . | quote }}
+  PSQL_PORT: {{ include "holdfast.postgres.port" . | quote }}
+  PSQL_USER: {{ include "holdfast.postgres.user" . | quote }}
+
+  STORAGE_ANALYTICS: {{ .Values.storage.analytics | quote }}
+
+  REACT_APP_PUBLIC_GRAPH_URI: {{ .Values.publicGraphUri | quote }}
+  REACT_APP_PRIVATE_GRAPH_URI: {{ .Values.privateGraphUri | quote }}
+  REACT_APP_FRONTEND_URI: {{ .Values.publicUrl | quote }}
+  COLLECTOR_OTLP_ENDPOINT: {{ .Values.collectorOtlpEndpoint | quote }}
+
+  AUTH_MODE: {{ .Values.auth.mode | quote }}

--- a/infra/helm/holdfast/templates/configmap.yaml
+++ b/infra/helm/holdfast/templates/configmap.yaml
@@ -6,15 +6,33 @@ metadata:
   labels:
     {{- include "holdfast.backend.labels" . | nindent 4 }}
 data:
+  # Postgres connection — read by HoldFast.Shared.Runtime.GoEnvCompat.
+  # Single-underscore names preserved from the legacy Go env-var contract.
   PSQL_HOST: {{ include "holdfast.postgres.host" . | quote }}
   PSQL_PORT: {{ include "holdfast.postgres.port" . | quote }}
   PSQL_USER: {{ include "holdfast.postgres.user" . | quote }}
 
-  STORAGE_ANALYTICS: {{ .Values.storage.analytics | quote }}
+  # Storage backend selector — the .NET host reads Configuration["Storage:Analytics"],
+  # which env-var-binds to STORAGE__ANALYTICS (double underscore is the .NET
+  # convention for nested config keys). Wrong name → defaultBackend falls back
+  # to "clickhouse" → ClickHouseMigrationService registers → backend crashes
+  # trying to connect to localhost:8123. Don't drop the second underscore.
+  STORAGE__ANALYTICS: {{ .Values.storage.analytics | quote }}
 
+  # Frontend URLs — REACT_APP_FRONTEND_URI is the only one the backend reads
+  # at runtime (via GoEnvCompat → Frontend:Uri). The graph URI vars are baked
+  # into the frontend bundle at build time and are kept here only as operator
+  # documentation of intent; they have no runtime effect on the backend.
+  REACT_APP_FRONTEND_URI: {{ .Values.publicUrl | quote }}
   REACT_APP_PUBLIC_GRAPH_URI: {{ .Values.publicGraphUri | quote }}
   REACT_APP_PRIVATE_GRAPH_URI: {{ .Values.privateGraphUri | quote }}
-  REACT_APP_FRONTEND_URI: {{ .Values.publicUrl | quote }}
-  COLLECTOR_OTLP_ENDPOINT: {{ .Values.collectorOtlpEndpoint | quote }}
 
-  AUTH_MODE: {{ .Values.auth.mode | quote }}
+  # Auth mode — backend GoEnvCompat maps REACT_APP_AUTH_MODE → Auth:Mode.
+  # Use REACT_APP_AUTH_MODE (not AUTH_MODE) so the value actually reaches the
+  # configuration.
+  REACT_APP_AUTH_MODE: {{ .Values.auth.mode | quote }}
+
+  # OTLP endpoint — for the backend to export its OWN telemetry to (it hosts
+  # OTLP receivers itself for incoming data). Empty string disables self-tracing.
+  # The .NET host reads OTEL_EXPORTER_OTLP_ENDPOINT (OTel SDK convention).
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.collectorOtlpEndpoint | quote }}

--- a/infra/helm/holdfast/templates/postgres-service.yaml
+++ b/infra/helm/holdfast/templates/postgres-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.postgres.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "holdfast.fullname" . }}-postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "holdfast.postgres.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.postgres.service.port }}
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    {{- include "holdfast.postgres.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/infra/helm/holdfast/templates/postgres-statefulset.yaml
+++ b/infra/helm/holdfast/templates/postgres-statefulset.yaml
@@ -47,15 +47,18 @@ spec:
                   key: {{ include "holdfast.postgres.secretKey" . }}
             - name: PGDATA
               value: {{ .Values.postgres.dataPath | quote }}
+          # -h 127.0.0.1 forces a TCP-based check via the loopback. The
+          # default socket-based check looks at /var/run/postgresql which
+          # TimescaleDB-HA images don't reliably expose.
           livenessProbe:
             exec:
-              command: ["pg_isready", "-U", {{ .Values.postgres.auth.user | quote }}]
+              command: ["pg_isready", "-U", {{ .Values.postgres.auth.user | quote }}, "-h", "127.0.0.1"]
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
           readinessProbe:
             exec:
-              command: ["pg_isready", "-U", {{ .Values.postgres.auth.user | quote }}]
+              command: ["pg_isready", "-U", {{ .Values.postgres.auth.user | quote }}, "-h", "127.0.0.1"]
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 5

--- a/infra/helm/holdfast/templates/postgres-statefulset.yaml
+++ b/infra/helm/holdfast/templates/postgres-statefulset.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.postgres.enabled -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "holdfast.fullname" . }}-postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "holdfast.postgres.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "holdfast.fullname" . }}-postgres
+  selector:
+    matchLabels:
+      {{- include "holdfast.postgres.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "holdfast.postgres.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          {{- with .Values.postgres.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.auth.user | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "holdfast.postgres.secretName" . }}
+                  key: {{ include "holdfast.postgres.secretKey" . }}
+            - name: PGDATA
+              value: {{ .Values.postgres.dataPath | quote }}
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgres.auth.user | quote }}]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.postgres.auth.user | quote }}]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+          {{- if .Values.postgres.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              # TimescaleDB-HA roots its data under /home/postgres/pgdata/;
+              # PGDATA above selects the actual data subdir.
+              mountPath: /home/postgres/pgdata
+          {{- end }}
+      {{- with .Values.postgres.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.postgres.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "holdfast.postgres.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.postgres.persistence.accessModes | nindent 10 }}
+        {{- if .Values.postgres.persistence.storageClassName }}
+        storageClassName: {{ .Values.postgres.persistence.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.persistence.size | quote }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/holdfast/templates/secret.yaml
+++ b/infra/helm/holdfast/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.postgres.enabled (not .Values.postgres.auth.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "holdfast.fullname" . }}-postgres
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "holdfast.postgres.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.postgres.auth.passwordKey }}: {{ required "postgres.auth.password is required when postgres.enabled=true and no existingSecret is set" .Values.postgres.auth.password | quote }}
+{{- end }}

--- a/infra/helm/holdfast/templates/serviceaccount.yaml
+++ b/infra/helm/holdfast/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "holdfast.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "holdfast.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/holdfast/values.lab.yaml
+++ b/infra/helm/holdfast/values.lab.yaml
@@ -25,7 +25,11 @@ postgres:
 publicUrl: https://holdfast.brewingcoder.com
 publicGraphUri: https://holdfast.brewingcoder.com/public
 privateGraphUri: https://holdfast.brewingcoder.com/private
-collectorOtlpEndpoint: https://holdfast.brewingcoder.com/otel
+# Self-export of backend telemetry: disabled in QA. The backend hosts its
+# own OTLP receivers for incoming data; self-tracing to the public hostname
+# 502s through Cloudflare and adds noise without value. Set to a real endpoint
+# in operator deployments that want backend traces shipped elsewhere.
+collectorOtlpEndpoint: ""
 
 # Auth handled at the CF Access edge in the lab; app stays in dev mode.
 auth:

--- a/infra/helm/holdfast/values.lab.yaml
+++ b/infra/helm/holdfast/values.lab.yaml
@@ -1,0 +1,26 @@
+# Lab-cluster overrides for the BrewingCoder microk8s QA environment.
+# Apply with: helm upgrade --install holdfast infra/helm/holdfast \
+#   -n holdfast --create-namespace \
+#   -f infra/helm/holdfast/values.lab.yaml \
+#   --set image.tag=<git-sha> \
+#   --set postgres.auth.password=<from-secret>
+
+image:
+  registry: localhost:32000
+  repository: holdfast-backend-dotnet
+  pullPolicy: Always       # tags overlap across builds in lab
+
+postgres:
+  persistence:
+    storageClassName: nfs-va-vm
+
+# Public URLs — Cloudflare tunnel terminates TLS at the edge; the backend
+# itself serves plain HTTP on :8080.
+publicUrl: https://holdfast.brewingcoder.com
+publicGraphUri: https://holdfast.brewingcoder.com/public
+privateGraphUri: https://holdfast.brewingcoder.com/private
+collectorOtlpEndpoint: https://holdfast.brewingcoder.com/otel
+
+# Auth handled at the CF Access edge in the lab; app stays in dev mode.
+auth:
+  mode: dev

--- a/infra/helm/holdfast/values.lab.yaml
+++ b/infra/helm/holdfast/values.lab.yaml
@@ -13,6 +13,12 @@ image:
 postgres:
   persistence:
     storageClassName: nfs-va-vm
+  auth:
+    # microk8s pre-created the holdfast-postgres Secret with key "password";
+    # chart's secret.yaml template is gated on `not .existingSecret` so it
+    # won't try to overwrite.
+    existingSecret: holdfast-postgres
+    passwordKey: password
 
 # Public URLs — Cloudflare tunnel terminates TLS at the edge; the backend
 # itself serves plain HTTP on :8080.

--- a/infra/helm/holdfast/values.yaml
+++ b/infra/helm/holdfast/values.yaml
@@ -49,9 +49,14 @@ backend:
   podSecurityContext: {}
   securityContext: {}
 
+  # Backend exposes a single /health endpoint (Program.cs uses
+  # app.MapHealthChecks("/health") — no live/ready split). Probing nested
+  # paths like /health/live falls through to the SPA index.html fallback
+  # which returns 200 → probes "pass" for the wrong reason. Don't change
+  # the path without re-checking what's actually mapped server-side.
   livenessProbe:
     httpGet:
-      path: /health/live
+      path: /health
       port: 8082
     initialDelaySeconds: 30
     periodSeconds: 10
@@ -60,7 +65,7 @@ backend:
 
   readinessProbe:
     httpGet:
-      path: /health/ready
+      path: /health
       port: 8082
     initialDelaySeconds: 10
     periodSeconds: 5

--- a/infra/helm/holdfast/values.yaml
+++ b/infra/helm/holdfast/values.yaml
@@ -1,0 +1,159 @@
+# Default values for the HoldFast helm chart.
+# Operators should override anything marked REQUIRED. Lab-specific defaults
+# live in values.lab.yaml; never edit values.yaml for environment-specific
+# overrides — author a values file or use --set on the command line.
+
+# ── Image -------------------------------------------------------------------
+image:
+  # Registry, repository, and tag for the HoldFast backend image.
+  # Lab cluster overrides registry to localhost:32000 via values.lab.yaml.
+  registry: ghcr.io
+  repository: brewingcoder/holdfast-backend-dotnet
+  # tag defaults to .Chart.AppVersion if empty
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+# ── ServiceAccount ---------------------------------------------------------
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# ── Backend pod -----------------------------------------------------------
+backend:
+  replicaCount: 1
+
+  # The Service name microk8s's Cloudflare tunnel points at must stay stable.
+  # Don't rename without coordinating with the cluster operator.
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+
+  livenessProbe:
+    httpGet:
+      path: /health/live
+      port: 8080
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  readinessProbe:
+    httpGet:
+      path: /health/ready
+      port: 8080
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  # Extra environment for the backend container. Use this for operator-
+  # specific config not covered by the typed values above.
+  # Each entry: { name: FOO, value: "bar" } or { name: FOO, valueFrom: ... }
+  extraEnv: []
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# ── Postgres (chart-managed) ----------------------------------------------
+# Set postgres.enabled = false to bring your own database via
+# externalPostgres.* below.
+postgres:
+  enabled: true
+
+  image:
+    repository: timescale/timescaledb-ha
+    tag: pg16
+    pullPolicy: IfNotPresent
+
+  service:
+    port: 5432
+
+  persistence:
+    enabled: true
+    size: 20Gi
+    # Empty storageClassName uses the cluster default. Lab cluster overrides
+    # to nfs-va-vm via values.lab.yaml.
+    storageClassName: ""
+    accessModes:
+      - ReadWriteOnce
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+
+  # TimescaleDB-HA stores data at /home/postgres/pgdata/data — NOT the
+  # upstream postgres /var/lib/postgresql/data. Don't change this unless
+  # you also change the image.
+  dataPath: /home/postgres/pgdata/data
+
+  auth:
+    user: postgres
+    # REQUIRED: set via --set postgres.auth.password=... or values file,
+    # OR reference an existing Secret via existingSecret/passwordKey.
+    password: ""
+    existingSecret: ""
+    passwordKey: password
+
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# ── External Postgres (alternative to chart-managed) ----------------------
+# Only used when postgres.enabled = false.
+externalPostgres:
+  host: ""
+  port: 5432
+  user: ""
+  passwordSecret:
+    name: ""
+    key: password
+
+# ── Storage backend selection ---------------------------------------------
+# Postgres = full analytics path via Postgres (no ClickHouse needed).
+# ClickHouse = OTeL-shaped columnar store (requires separate ClickHouse pod;
+# this chart does not yet manage one — bring your own).
+storage:
+  analytics: Postgres
+
+# ── External URLs ---------------------------------------------------------
+# REQUIRED — operators must set these to the publicly-reachable URLs of
+# their HoldFast deployment. No hardcoded domains per the HoldFast charter.
+publicUrl: ""              # e.g. https://holdfast.example.com
+publicGraphUri: ""         # e.g. https://holdfast.example.com/public
+privateGraphUri: ""        # e.g. https://holdfast.example.com/private
+collectorOtlpEndpoint: ""  # e.g. https://holdfast.example.com/otel
+
+# ── Auth ------------------------------------------------------------------
+# v1 of this chart only supports auth.mode=dev (no in-app authentication).
+# Operators wanting in-app auth should front the deployment with a
+# zero-trust proxy (Cloudflare Access, Authelia, oauth2-proxy, etc.) until
+# enterprise mode is wired into the chart (planned).
+auth:
+  mode: dev

--- a/infra/helm/holdfast/values.yaml
+++ b/infra/helm/holdfast/values.yaml
@@ -119,7 +119,13 @@ postgres:
     existingSecret: ""
     passwordKey: password
 
-  podSecurityContext: {}
+  # Default fsGroup matches `postgres` UID in timescale/timescaledb-ha:pg16
+  # (UID 1000). PSA-restricted clusters require this to be set; permissive
+  # clusters don't care, so this costs nothing and saves an operator who
+  # adopts a stricter cluster profile from one debug cycle.
+  # Override if you swap the image to one that runs as a different UID.
+  podSecurityContext:
+    fsGroup: 1000
   securityContext: {}
   nodeSelector: {}
   tolerations: []

--- a/infra/helm/holdfast/values.yaml
+++ b/infra/helm/holdfast/values.yaml
@@ -28,11 +28,12 @@ serviceAccount:
 backend:
   replicaCount: 1
 
-  # The Service name microk8s's Cloudflare tunnel points at must stay stable.
-  # Don't rename without coordinating with the cluster operator.
+  # Backend Kestrel binds on 8082 (see infra/docker/backend-dotnet.Dockerfile
+  # `ENV ASPNETCORE_URLS=http://+:8082`). If you change the bind port, update
+  # this AND the cluster operator's tunnel/ingress rule.
   service:
     type: ClusterIP
-    port: 8080
+    port: 8082
     annotations: {}
 
   resources:
@@ -51,7 +52,7 @@ backend:
   livenessProbe:
     httpGet:
       path: /health/live
-      port: 8080
+      port: 8082
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
@@ -60,7 +61,7 @@ backend:
   readinessProbe:
     httpGet:
       path: /health/ready
-      port: 8080
+      port: 8082
     initialDelaySeconds: 10
     periodSeconds: 5
     timeoutSeconds: 5


### PR DESCRIPTION
## Summary

- Replaces ad-hoc `dotnet`/`yarn`/`docker` shell scripting with a [Tamp](https://github.com/tamp-build/tamp)-driven build pipeline in `build/Build.cs`. One command (`dotnet tamp Ci`) covers Restore → Compile → Test → Publish → YarnInstall → FrontendBuild → DockerBuildBackend. A second command (`dotnet tamp SmokeQa`) chains push → helm install → /health verification.
- Adds an AGPL-operator-consumable Helm chart at `infra/helm/holdfast/` — two-pod deployment (backend + postgres), community-idiomatic labels, sensible operator defaults, lab-cluster overrides in `values.lab.yaml`.
- **Cutover criterion proven against the lab cluster**: `dotnet tamp SmokeQa --registry registry.home.local` ships the image and verifies `https://holdfast.brewingcoder.com/health` returns `Healthy` in 3.3 seconds (cache-warm).
- **Wave 2 (post-cutover)**: bumps Tamp to current (Core 1.7.0) and wires the supply-chain + coverage + codegen satellites: Syft, Grype, TruffleHog, GraphQLCodegen, Coverlet, ReportGenerator. 20 targets total; `Compliance` aggregate fans out to SbomScan + CveGate + SecretScan.

## What lands

| Layer | Files | Net |
|---|---|---|
| Tamp build script | `build/Build.cs`, `build/Build.csproj` | wave 1 + wave 2 |
| Helm chart | `infra/helm/holdfast/` — Chart.yaml, values.yaml, values.lab.yaml, README, .helmignore, 8 templates | ~750 |
| .gitignore tweak | un-ignore `/build/` (the `**/build` rule otherwise hides it) | 10 |
| CHANGELOG | one focused entry documenting this scope only (HOL-53 docs sweep deferred) | 78 |

Existing `compose -f compose.yml -f compose.hobby-dotnet.yml up` hobby flow is unchanged.

## Backend pipeline (`build/Build.cs`)

20 targets enumerated by `dotnet tamp --list`:

```
Ci · Clean · Compile · Compliance · CoverageReport · CoverageTest · CveGate
DeployQa · DockerBuildBackend · DockerPush · FrontendBuild · FrontendCodegen
Info · Publish · Restore · SbomScan · SecretScan · SmokeQa · Test · YarnInstall
```

Idiomatic 5-line Tamp shape:

```csharp
[FromPath("yarn")]                              readonly Tool YarnTool       = null!;
[FromPath("helm")]                              readonly Tool HelmTool       = null!;
[FromPath("syft", Optional = true)]             readonly Tool SyftTool       = null!;
[FromNodeModules("turbo")]                      readonly Tool TurboTool      = null!;

Target SbomScan => _ => _.Executes(() => Syft.Scan(SyftTool, s => s.SetDirectorySource(RootDirectory).AddOutputCycloneDxJson(Sbom)));
Target CveGate  => _ => _.DependsOn(SbomScan).Executes(() => Grype.Scan(GrypeTool, s => s.SetSbomSource(Sbom).SetFailOn("high").SetByCve(true)));
Target Compliance => _ => _.DependsOn(SbomScan, CveGate, SecretScan);
Target Ci => _ => _.Default().DependsOn(Test, Publish, FrontendBuild, DockerBuildBackend);
```

Pin set (post-Wave-2):

```xml
Tamp.Core           1.7.0   <!-- TAMP001-004 analyzers, async overloads, Secret.Reveal public -->
Tamp.NetCli.V10     1.4.0
Tamp.Docker.V27     0.3.1   ·   Tamp.Helm.V3   0.1.0   ·   Tamp.Http   0.1.1
Tamp.Yarn.V4        0.1.1   ·   Tamp.Turbo.V2  0.2.1   ·   Tamp.Vite.V5  0.1.1
Tamp.GraphQLCodegen.V5  0.1.1
Tamp.Coverlet.V6   0.1.0    ·   Tamp.ReportGenerator.V5  0.1.1
Tamp.Syft  0.1.0    ·   Tamp.Grype  0.1.0    ·   Tamp.TruffleHog.V3  0.1.1
```

Compliance (SBOM + CVE + secret scan) is deliberately **not** part of `Ci` so the fast iteration path stays fast; release-prep runs `dotnet tamp Compliance` on demand. Same shape for `CoverageTest` / `CoverageReport` (run on demand, not per-build).

## Helm chart (`infra/helm/holdfast/`)

Two pods. Renders 7 resources:

```
ServiceAccount  holdfast
Secret          holdfast-postgres            (chart-managed OR existingSecret)
ConfigMap       holdfast-backend             (PSQL_*, STORAGE__ANALYTICS, etc.)
Service         holdfast-backend  :8082      (ClusterIP, named `http`)
Service         holdfast-postgres :5432      (ClusterIP, internal only)
Deployment      holdfast-backend             (1 replica, /health probes)
StatefulSet     holdfast-postgres            (1 replica, volumeClaimTemplate)
```

Chart-managed Postgres by default (TimescaleDB-HA pg16, `fsGroup: 1000` for AGPL-portable PSA-restricted compatibility). Operators bring-your-own via `postgres.enabled=false` + `externalPostgres.*`.

Auth: `auth.mode=dev` only in v1 — README documents the operator-must-front-with-ZTA-proxy guidance. Enterprise in-app auth is roadmapped.

## Trial findings (frictions caught + filed)

**Tamp side, wave 1 (16 frictions, all filed with airm5, all closed in coordinated waves):**
- Friction #1–#11 caught during initial integration → closed in Tamp 1.0.8 / 1.0.9 / 1.0.10
- Friction #12 (CleanArtifacts safety critical) → TAM-127 → Tamp.Core 1.0.10
- Friction #14 (`DependsOn` varargs takes string[] not Target[]) → TAM-159 → Tamp.Core 1.3.0 `params Target[]`
- Friction #15 + #16 caught during the deploy spiral — CLI param case + `readonly` parameter silently ignored

**Tamp side, wave 2 (4 new frictions filed):**
- **#17** — `Tamp.GitVersion.V6 0.1.1` is missing the `[GitVersion]` injection attribute + `GitVersionInfo` result type the README implies. Backed out — short-SHA tag still works.
- **#18** — Target name vs static-class name collision. A target named `GraphQLCodegen` shadows the satellite's static class. Renamed to `FrontendCodegen`. Worth a per-satellite README note.
- **#19** — Coverlet → DotNet.Test integration is non-obvious. Pattern is `Coverlet.Configure → ToRunSettingsXml → File.WriteAllText → DotNet.Test.SetSettings`. Discovered via reflection; should be documented.
- **#20** — `[FromPath]` injection is eager by default. `dotnet tamp --list` blew up because trufflehog wasn't on PATH. Fix: `Optional = true`. Worth a clear README note.

**TAMP001 saved a real bug**: my first cut of `CoverageTest` dropped the `DotNet.Test` plan inside a multi-statement `Executes(Action)` lambda — the analyzer caught it on first compile and pointed me at the fix. Day-1-catch confirmed twice.

**HoldFast side (5 chart bugs caught and fixed inline during wave 1):**
- Postgres probe used Unix socket TimescaleDB-HA doesn't expose → use `-h 127.0.0.1` TCP loopback
- ConfigMap had `STORAGE_ANALYTICS` not `STORAGE__ANALYTICS` (.NET config-key convention)
- Same shape for `AUTH_MODE` → should be `REACT_APP_AUTH_MODE` (per `GoEnvCompat`)
- Dockerfile binds `:8082`, chart had `:8080` everywhere
- Probes hit `/health/live` — SPA fallback returned 200 (silent lie). Real endpoint is `/health`

Each captured in a commit on this branch; see `git log` for the post-mortem.

## What's NOT in this PR

Deliberately scoped out — opening as follow-ups after merge:

- **In-cluster SmokeQa default URL** — microk8s's recommendation. `SmokeQa` should default to `http://holdfast-backend.holdfast.svc.cluster.local:8082/health` (no CF hop) and a separate `SmokeQaPublic` target probes the public URL.
- **Tamp.GitVersion.V6 semver image tags** — blocked on friction #17 (missing `[GitVersion]` injection attribute). Currently uses `Git.Commit[..7]`.
- **HOL-53** — broader `docs/HOLDFAST-NOTES.md` + `docs/CHANGELOG-FORK.md` sweep to reflect the full post-rewrite architecture (this PR adds one focused entry for the build/deploy scope only).
- **CI/CD re-enablement** — workflows stay disabled. Flipping `gh workflow enable` after this lands is its own concern.

## Test plan

- [x] `dotnet tamp --list` — 20 targets enumerate clean on a machine without syft/grype/trufflehog (Optional flag works)
- [x] `dotnet build build/Build.csproj` — 0 warnings, 0 errors against Tamp.Core 1.7.0
- [x] `dotnet tamp Info` — 6 ms, prints config / git / image tag / QA URL
- [x] `dotnet tamp Test` (wave 1) — 3,172/3,172 green in 21.4s
- [x] `dotnet tamp DockerBuildBackend` — 485 MB image, byte-size parity with the legacy `docker build` baseline
- [x] `dotnet tamp Publish` — `artifacts/publish/HoldFast.Api/` byte-identical to raw `dotnet publish`
- [x] `dotnet tamp FrontendBuild` — 17/17 turbo tasks green via direct `Turbo.Run`
- [x] `dotnet tamp DeployQa --registry registry.home.local` — `helm upgrade --install` against `va-mk8s-1..6`, both pods reach Ready
- [x] `dotnet tamp SmokeQa --registry registry.home.local` — `https://holdfast.brewingcoder.com/health` returns `Healthy` via Cloudflare tunnel
- [x] `helm lint infra/helm/holdfast` clean; `helm install --dry-run` validates against live API server

## Coordinated work

- **airm5** — shipped 40+ Tamp packages across 9+ release waves to address frictions surfaced here. Tamp.Helm.V3 0.1.0 was authored specifically for the cutover. Wave 2 additions (Syft, Grype, TruffleHog wrappers) shipped 2026-05-13.
- **microk8s** — provisioned namespace `holdfast`, ARC runner RBAC (`edit` in `holdfast` ns), CF tunnel (`holdfast.brewingcoder.com` → `:8082`), DNS, WAF Skip rule, pre-created `holdfast-postgres` Secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
